### PR TITLE
Fix Next.js config for v14

### DIFF
--- a/apps/autos/next.config.js
+++ b/apps/autos/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    transpilePackages: ['@rfwebapp/ui']
-  }
+  transpilePackages: ['@rfwebapp/ui']
 };
 
 module.exports = nextConfig;

--- a/apps/core/next.config.js
+++ b/apps/core/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    transpilePackages: ['@rfwebapp/ui']
-  }
+  transpilePackages: ['@rfwebapp/ui']
 };
 
 module.exports = nextConfig;

--- a/apps/dashboards/next.config.js
+++ b/apps/dashboards/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    transpilePackages: ['@rfwebapp/ui']
-  }
+  transpilePackages: ['@rfwebapp/ui']
 };
 
 module.exports = nextConfig;

--- a/apps/expenses/next.config.js
+++ b/apps/expenses/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    transpilePackages: ['@rfwebapp/ui']
-  }
+  transpilePackages: ['@rfwebapp/ui']
 };
 
 module.exports = nextConfig;

--- a/apps/inventory/next.config.js
+++ b/apps/inventory/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    transpilePackages: ['@rfwebapp/ui']
-  }
+  transpilePackages: ['@rfwebapp/ui']
 };
 
 module.exports = nextConfig;

--- a/apps/rh/next.config.js
+++ b/apps/rh/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    transpilePackages: ['@rfwebapp/ui']
-  }
+  transpilePackages: ['@rfwebapp/ui']
 };
 
 module.exports = nextConfig;

--- a/apps/timesheet/next.config.js
+++ b/apps/timesheet/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    transpilePackages: ['@rfwebapp/ui']
-  }
+  transpilePackages: ['@rfwebapp/ui']
 };
 
 module.exports = nextConfig;

--- a/apps/vendors/next.config.js
+++ b/apps/vendors/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    transpilePackages: ['@rfwebapp/ui']
-  }
+  transpilePackages: ['@rfwebapp/ui']
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- follow Next.js 14 config guidance
- move `transpilePackages` out of `experimental`

## Testing
- `pnpm install`
- `pnpm --filter core dev`
- `pnpm lint` *(fails: React must be in scope when using JSX)*

------
https://chatgpt.com/codex/tasks/task_e_684ff2783b2083329882260d9e361424