### PR TITLE
Add auth store with persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Como usar na tua app:
 import { Button } from '@RFWebApp/ui';
 <Button variant="primary">Salvar</Button>;
 ```
+Outro exemplo com `AppShortcutCard`:
+```tsx
+import { AppShortcutCard } from '@RFWebApp/ui';
+<AppShortcutCard title="RH" icon="👥" href="/rh" />
+```
 
 Tailwind com preset da UI:
 
@@ -83,6 +88,7 @@ export default {
 Envvolva a aplicação com `ThemeProvider` e importe `@RFWebApp/ui/styles/themes.css`.
 Use o hook `usePrefs` ou o componente `ThemeToggle` para alterar entre `light`,
 `dark` e `high-contrast`. As preferências são guardadas em `localStorage`.
+Existe uma página `/settings` onde o utilizador pode mudar o tema e definir o funcionário ativo.
 
 🧠 Adicionar um novo microserviço
 
@@ -130,6 +136,11 @@ SELECT Number, Name FROM Employee WHERE UserId = @upn AND Active = 1
 - Se múltiplos: mostrar UI de seleção de funcionário
 - Guardar `employeeNumber` via Zustand + localStorage
 - Middleware bloqueia apps sensíveis se não houver funcionário
+- Store persistente `useAuthStore` mantém `employeeNumber`, `userName` e `roles`.
+- Hook `useRequireAuth` redireciona para `/login` ou `/landing`.
+- Endpoint `/api/funcionarios?email=...` devolve os funcionários associados.
+- A página `/landing` usa esse endpoint para selecionar o funcionário ativo.
+- Cada app possui `middleware.ts` que valida os cookies `AuthSession` e `Employee`.
 
 📱 Página de apps disponíveis (`/apps`)
 

--- a/apps/autos/middleware.ts
+++ b/apps/autos/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const auth = req.cookies.get('AuthSession');
+  if (!auth) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+  const employee = req.cookies.get('Employee');
+  if (!employee) {
+    return NextResponse.redirect(new URL('/landing', req.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/settings', '/autos/:path*', '/rh/:path*'],
+};

--- a/apps/core/middleware.ts
+++ b/apps/core/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const auth = req.cookies.get('AuthSession');
+  if (!auth) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+  const employee = req.cookies.get('Employee');
+  if (!employee) {
+    return NextResponse.redirect(new URL('/landing', req.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/settings', '/autos/:path*', '/rh/:path*'],
+};

--- a/apps/core/src/pages/api/funcionarios.ts
+++ b/apps/core/src/pages/api/funcionarios.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import sql from 'mssql';
+
+const sqlConfig = {
+  user: process.env.SQL_USER,
+  password: process.env.SQL_PASSWORD,
+  server: process.env.SQL_SERVER,
+  database: process.env.SQL_DATABASE,
+  options: {
+    encrypt: true,
+    trustServerCertificate: true,
+  },
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const email = req.query.email as string;
+  if (!email) return res.status(400).json({ message: 'Missing email' });
+
+  try {
+    await sql.connect(sqlConfig);
+    const result = await sql.query`SELECT [Id] AS id, [Name] AS nome, [Title] AS cargo FROM Employee WHERE Email = ${email} AND Active = 1`;
+    res.status(200).json(result.recordset);
+  } catch (err: any) {
+    res.status(500).json({ message: err.message });
+  } finally {
+    sql.close();
+  }
+}

--- a/apps/core/src/pages/landing.tsx
+++ b/apps/core/src/pages/landing.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useIsAuthenticated, useMsal } from '@azure/msal-react';
+import {
+  Card,
+  Button,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalFooter
+} from '@RFWebApp/ui';
+import { useAuthStore } from '../../../../src/store/auth';
+
+interface Funcionario {
+  id: string;
+  nome: string;
+  cargo: string;
+}
+
+const apps = [
+  { href: '/rh', title: 'RH', icon: '👥' },
+  { href: '/autos', title: 'Autos', icon: '📄' },
+  { href: '/core', title: 'Core', icon: '🏠' }
+];
+
+export default function LandingPage() {
+  const isAuthenticated = useIsAuthenticated();
+  const { accounts } = useMsal();
+  const router = useRouter();
+  const { employeeNumber, setEmployeeNumber } = useAuthStore();
+  const [employees, setEmployees] = useState<Funcionario[]>([]);
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState('');
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.replace('/login');
+    }
+  }, [isAuthenticated, router]);
+
+  useEffect(() => {
+    async function load() {
+      if (!isAuthenticated || !accounts[0]) return;
+      try {
+        const res = await fetch(
+          `/api/funcionarios?email=${encodeURIComponent(accounts[0].username)}`
+        );
+        const data: Funcionario[] = await res.json();
+        setEmployees(data);
+        if (data.length === 1) {
+          setEmployeeNumber(String(data[0].id));
+        } else if (!employeeNumber) {
+          setOpen(true);
+        }
+      } catch {
+        // ignore
+      }
+    }
+    load();
+  }, [isAuthenticated, accounts, employeeNumber, setEmployeeNumber]);
+
+  const handleSelect = () => {
+    if (selected) {
+      setEmployeeNumber(selected);
+      setOpen(false);
+    }
+  };
+
+  return (
+    <main className="p-4 space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {apps.map((app) => (
+          <a key={app.href} href={app.href} className="block">
+            <Card className="p-6 flex flex-col items-center text-center space-y-2">
+              <span className="text-4xl">{app.icon}</span>
+              <span className="text-lg font-semibold">{app.title}</span>
+            </Card>
+          </a>
+        ))}
+      </div>
+      <Modal open={open} onOpenChange={setOpen}>
+        <ModalContent>
+          <ModalHeader>
+            <ModalTitle>Selecionar Funcionário</ModalTitle>
+          </ModalHeader>
+          <select
+            className="w-full border p-2 rounded"
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+          >
+            <option value="">Escolha...</option>
+            {employees.map((emp) => (
+              <option key={emp.id} value={emp.id}>
+                {emp.nome}
+              </option>
+            ))}
+          </select>
+          <ModalFooter>
+            <Button onClick={handleSelect}>Confirmar</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </main>
+  );
+}

--- a/apps/core/src/pages/select-employee.tsx
+++ b/apps/core/src/pages/select-employee.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useState } from 'react';
-import { useAuthStore } from '../../../lib/useAuthStore';
+import { useAuthStore } from '../../../../src/store/auth';
 import { useRouter } from 'next/router';
 
 export default function SelectEmployee() {

--- a/apps/core/src/pages/settings.tsx
+++ b/apps/core/src/pages/settings.tsx
@@ -1,0 +1,131 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { useIsAuthenticated, useMsal } from '@azure/msal-react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  Button,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalFooter,
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+  usePrefs
+} from '@RFWebApp/ui';
+import { useAuthStore } from '../../../../src/store/auth';
+
+interface Funcionario {
+  id: string;
+  nome: string;
+  cargo: string;
+}
+
+export default function SettingsPage() {
+  const isAuthenticated = useIsAuthenticated();
+  const { accounts } = useMsal();
+  const router = useRouter();
+  const { employeeNumber, setEmployeeNumber } = useAuthStore();
+  const { theme, setTheme } = usePrefs();
+  const [employees, setEmployees] = useState<Funcionario[]>([]);
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState(employeeNumber || '');
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.replace('/login');
+    }
+  }, [isAuthenticated, router]);
+
+  const loadEmployees = async () => {
+    if (!accounts[0]) return;
+    try {
+      const res = await fetch(
+        `/api/funcionarios?email=${encodeURIComponent(accounts[0].username)}`
+      );
+      const data: Funcionario[] = await res.json();
+      setEmployees(data);
+      setOpen(true);
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleSelect = () => {
+    if (selected) {
+      setEmployeeNumber(selected);
+      setOpen(false);
+    }
+  };
+
+  return (
+    <main className="p-4 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Utilizador</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1">
+          <div>{accounts[0]?.name}</div>
+          <div className="text-sm text-muted-foreground">{accounts[0]?.username}</div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Tema</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Select value={theme} onValueChange={(v) => setTheme(v as any)}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Escolha o tema" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="light">Claro</SelectItem>
+              <SelectItem value="dark">Escuro</SelectItem>
+              <SelectItem value="high-contrast">Daltônico</SelectItem>
+            </SelectContent>
+          </Select>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Funcionário Ativo</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center gap-2">
+          <span>{employeeNumber || 'Nenhum selecionado'}</span>
+          <Button onClick={loadEmployees}>Trocar</Button>
+        </CardContent>
+      </Card>
+
+      <Modal open={open} onOpenChange={setOpen}>
+        <ModalContent>
+          <ModalHeader>
+            <ModalTitle>Selecionar Funcionário</ModalTitle>
+          </ModalHeader>
+          <select
+            className="w-full border p-2 rounded"
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+          >
+            <option value="">Escolha...</option>
+            {employees.map((emp) => (
+              <option key={emp.id} value={emp.id}>
+                {emp.nome}
+              </option>
+            ))}
+          </select>
+          <ModalFooter>
+            <Button onClick={handleSelect}>Confirmar</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </main>
+  );
+}

--- a/apps/dashboards/middleware.ts
+++ b/apps/dashboards/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const auth = req.cookies.get('AuthSession');
+  if (!auth) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+  const employee = req.cookies.get('Employee');
+  if (!employee) {
+    return NextResponse.redirect(new URL('/landing', req.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/settings', '/autos/:path*', '/rh/:path*'],
+};

--- a/apps/expenses/middleware.ts
+++ b/apps/expenses/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const auth = req.cookies.get('AuthSession');
+  if (!auth) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+  const employee = req.cookies.get('Employee');
+  if (!employee) {
+    return NextResponse.redirect(new URL('/landing', req.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/settings', '/autos/:path*', '/rh/:path*'],
+};

--- a/apps/inventory/middleware.ts
+++ b/apps/inventory/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const auth = req.cookies.get('AuthSession');
+  if (!auth) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+  const employee = req.cookies.get('Employee');
+  if (!employee) {
+    return NextResponse.redirect(new URL('/landing', req.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/settings', '/autos/:path*', '/rh/:path*'],
+};

--- a/apps/rh/middleware.ts
+++ b/apps/rh/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const auth = req.cookies.get('AuthSession');
+  if (!auth) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+  const employee = req.cookies.get('Employee');
+  if (!employee) {
+    return NextResponse.redirect(new URL('/landing', req.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/settings', '/autos/:path*', '/rh/:path*'],
+};

--- a/apps/timesheet/middleware.ts
+++ b/apps/timesheet/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const auth = req.cookies.get('AuthSession');
+  if (!auth) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+  const employee = req.cookies.get('Employee');
+  if (!employee) {
+    return NextResponse.redirect(new URL('/landing', req.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/settings', '/autos/:path*', '/rh/:path*'],
+};

--- a/apps/vendors/middleware.ts
+++ b/apps/vendors/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const auth = req.cookies.get('AuthSession');
+  if (!auth) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+  const employee = req.cookies.get('Employee');
+  if (!employee) {
+    return NextResponse.redirect(new URL('/landing', req.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/settings', '/autos/:path*', '/rh/:path*'],
+};

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,1 +1,1 @@
-export { useAuthStore as useAppStore } from './useAuthStore';
+export { useAuthStore as useAppStore } from '../src/store/auth';

--- a/lib/useRequireAuth.ts
+++ b/lib/useRequireAuth.ts
@@ -1,24 +1,22 @@
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { useAuthStore } from './useAuthStore';
-
-export function useRequireAuth(redirect = true) {
-  const { employeeNumber, setEmployeeNumber } = useAuthStore();
+import { useIsAuthenticated } from '@azure/msal-react';
+import { useAuthStore } from '../src/store/auth';
+export function useRequireAuth() {
+  const isAuthenticated = useIsAuthenticated();
+  const { employeeNumber } = useAuthStore();
   const router = useRouter();
 
   useEffect(() => {
-    if (!employeeNumber) {
-      const cookie = document.cookie
-        .split('; ')
-        .find((r) => r.startsWith('employeeNumber='))
-        ?.split('=')[1];
-      if (cookie) {
-        setEmployeeNumber(cookie);
-      } else if (redirect) {
-        router.push('/core');
-      }
+    if (!isAuthenticated) {
+      router.push('/login');
+      return;
     }
-  }, [employeeNumber, redirect, router, setEmployeeNumber]);
+
+    if (!employeeNumber) {
+      router.push('/landing');
+    }
+  }, [isAuthenticated, employeeNumber, router]);
 
   return employeeNumber;
 }

--- a/packages/ui/src/components/app-shortcut-card.tsx
+++ b/packages/ui/src/components/app-shortcut-card.tsx
@@ -1,0 +1,31 @@
+import { ReactNode, useEffect, useRef } from 'react';
+import Link from 'next/link';
+import { Card } from './card';
+import { cn } from '../lib/utils';
+import { gsap } from 'gsap';
+
+export interface AppShortcutCardProps {
+  title: string;
+  icon: ReactNode;
+  href: string;
+  className?: string;
+}
+
+export function AppShortcutCard({ title, icon, href, className }: AppShortcutCardProps) {
+  const ref = useRef<HTMLAnchorElement | null>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      gsap.fromTo(ref.current, { opacity: 0, y: 10 }, { opacity: 1, y: 0 });
+    }
+  }, []);
+
+  return (
+    <Link href={href} ref={ref} className={cn('block h-full', className)}>
+      <Card className="flex flex-col items-center justify-center gap-2 p-4 text-center hover:bg-accent transition-colors h-full">
+        <span className="text-2xl">{icon}</span>
+        <span className="font-medium">{title}</span>
+      </Card>
+    </Link>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,6 +16,7 @@ export * from './components/table';
 export * from './components/tabs';
 export * from './components/textarea';
 export * from './components/app-card';
+export * from './components/app-shortcut-card';
 export * from './components/modal';
 export * from './components/theme-provider';
 export * from './components/theme-toggle';

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface AuthState {
+  employeeNumber: string | null;
+  userName: string | null;
+  roles: string[];
+  setEmployee: (employeeNumber: string | null, userName: string | null, roles?: string[]) => void;
+  clearSession: () => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      employeeNumber: null,
+      userName: null,
+      roles: [],
+      setEmployee: (employeeNumber, userName, roles = []) =>
+        set({ employeeNumber, userName, roles }),
+      clearSession: () => set({ employeeNumber: null, userName: null, roles: [] })
+    }),
+    { name: 'auth-storage' }
+  )
+);


### PR DESCRIPTION
## Summary
- create `useAuthStore` Zustand hook in `src/store/auth.ts`
- update pages and helpers to import the new hook
- add `useRequireAuth` hook to redirect to login or landing when needed
- add `AppShortcutCard` component to `@RFWebApp/ui`
- update README with new features

## Testing
- `pnpm install`
- `npm run lint` *(fails: 4165 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685018ef5a148332acb0fd327ddc1467