### PR TITLE
Implement MSAL login callback API

### DIFF
--- a/apps/core/src/pages/api/login-callback.ts
+++ b/apps/core/src/pages/api/login-callback.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PublicClientApplication } from '@azure/msal-browser';
+import { authConfig } from '../../authConfig';
+
+const msalInstance = new PublicClientApplication({
+  auth: {
+    clientId: authConfig.clientId,
+    authority: `https://login.microsoftonline.com/${authConfig.tenantId}`,
+    redirectUri: authConfig.redirectUri
+  }
+});
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const hash = (req.method === 'POST' ? req.body?.hash : req.query.hash) as string | undefined;
+  if (!hash) {
+    return res.status(400).json({ message: 'Missing hash' });
+  }
+
+  try {
+    const response = await msalInstance.handleRedirectPromise(hash);
+    const token = response?.accessToken;
+
+    if (!token) {
+      return res.status(400).json({ message: 'Token not found' });
+    }
+
+    res.setHeader('Set-Cookie', `AuthSession=${token}; HttpOnly; Path=/; Secure; SameSite=Lax`);
+    res.writeHead(302, { Location: '/landing' });
+    res.end();
+  } catch (err: any) {
+    res.status(500).json({ message: err.message });
+  }
+}

--- a/apps/core/src/pages/index.tsx
+++ b/apps/core/src/pages/index.tsx
@@ -8,6 +8,12 @@ export default function Home() {
   const router = useRouter();
 
   useEffect(() => {
+    const hash = window.location.hash;
+    if (hash) {
+      window.location.href = `/api/login-callback?hash=${encodeURIComponent(hash)}`;
+      return;
+    }
+
     if (!instance.getActiveAccount()) {
       instance.loginRedirect(loginRequest);
     } else {


### PR DESCRIPTION
## Summary
- create `login-callback` API route for MSAL redirect
- store `AuthSession` cookie and redirect to `/landing`
- update core login page to send auth hash to the API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504549e24483328517daccb168b924