### PR TITLE
Add MSAL login page

### DIFF
--- a/apps/core/src/pages/login.tsx
+++ b/apps/core/src/pages/login.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useMsal, useIsAuthenticated } from '@azure/msal-react';
+import { Button } from '@RFWebApp/ui';
+import { loginRequest } from '../utils/authRequest';
+import { useAuthStore } from '../../../../src/store/auth';
+
+export default function LoginPage() {
+  const { instance } = useMsal();
+  const isAuthenticated = useIsAuthenticated();
+  const { employeeNumber } = useAuthStore();
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    instance
+      .handleRedirectPromise()
+      .finally(() => setLoading(false));
+  }, [instance]);
+
+  useEffect(() => {
+    if (!loading && isAuthenticated) {
+      router.replace(employeeNumber ? '/apps' : '/landing');
+    }
+  }, [loading, isAuthenticated, employeeNumber, router]);
+
+  const handleLogin = () => {
+    setLoading(true);
+    instance.loginRedirect(loginRequest);
+  };
+
+  if (loading) {
+    return <div className="p-4">Carregando...</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <Button onClick={handleLogin}>Entrar</Button>
+    </div>
+  );
+}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../apps/core/src/pages/login';


### PR DESCRIPTION
## Summary
- add login page for the core app
- re-export login page from repo root so `/login` works everywhere

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6850450f197083329ae419e39ee54164