### PR TITLE
Implement MSAL login callback

### DIFF
--- a/apps/core/src/pages/api/login-callback.ts
+++ b/apps/core/src/pages/api/login-callback.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { msalInstance } from '../../../../lib/auth/msal';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const response = await msalInstance.handleRedirectPromise();
+    const token = response?.accessToken;
+    if (token) {
+      res.setHeader(
+        'Set-Cookie',
+        `AuthSession=${token}; HttpOnly; Path=/; Secure`
+      );
+      res.writeHead(302, { Location: '/landing' });
+      res.end();
+    } else {
+      res.status(400).json({ message: 'No token found' });
+    }
+  } catch (err: any) {
+    res.status(500).json({ message: err.message });
+  }
+}

--- a/apps/core/src/pages/index.tsx
+++ b/apps/core/src/pages/index.tsx
@@ -11,7 +11,9 @@ export default function Home() {
     if (!instance.getActiveAccount()) {
       instance.loginRedirect(loginRequest);
     } else {
-      router.replace('/apps');
+      fetch('/api/login-callback').then(() => {
+        router.replace('/landing');
+      });
     }
   }, [instance, router]);
 


### PR DESCRIPTION
## Summary
- create `login-callback` API route for MSAL redirect handling
- persist AuthSession cookie and redirect to `/landing`
- update login page to call the API after authentication

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68504522c0a883329a6a1fbc52ea9b68