### PR TITLE
Add roadmap section linking to issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,12 @@ Cada microserviço possui um endpoint `api/analytics` que recolhe navegação e
 erros de runtime. O hook `useAnalytics(service)` envia eventos automaticamente
 em cada mudança de rota e captura falhas globais.
 
-✅ A fazer / melhorias futuras
+🛣️ Roadmap para versão 1.0
 
-- [ ] Criar Modal, Tabs, Tooltip, AppCard animados na UI
-- [ ] Criar layout base com Navbar lateral e topbar
-- [ ] Criar design tokens exportáveis para Figma
-- [ ] Publicar `@RFWebApp/ui` em NPM privado (GitHub Packages)
-- [ ] Criar fallback de autenticação para outros provedores (ex: Azure B2B)
+- [ ] [Adicionar componentes animados](https://github.com/GimMarSil/rf-web-platform/issues/1)
+- [ ] [Implementar layout base](https://github.com/GimMarSil/rf-web-platform/issues/2)
+- [ ] [Gerar design tokens para Figma](https://github.com/GimMarSil/rf-web-platform/issues/3)
+- [ ] [Publicar `@RFWebApp/ui` no GitHub Packages](https://github.com/GimMarSil/rf-web-platform/issues/4)
+- [ ] [Adicionar fallback de autenticação](https://github.com/GimMarSil/rf-web-platform/issues/5)
+
+Consulte [docs/roadmap.md](docs/roadmap.md) para mais detalhes sobre estas tarefas.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,11 @@
+# Roadmap para versão 1.0
+
+A lista abaixo detalha as melhorias planeadas. Cada item deverá ser acompanhado por um issue no GitHub assim que possível.
+
+1. **Adicionar componentes animados** – Modal, Tabs, Tooltip e AppCard na biblioteca `@RFWebApp/ui`.
+2. **Implementar layout base** – Navbar lateral e topbar partilhada entre micro-serviços.
+3. **Gerar design tokens para Figma** – Exportar cores, tipografia e espaçamentos.
+4. **Publicar `@RFWebApp/ui` no GitHub Packages** – Distribuição privada via NPM.
+5. **Adicionar fallback de autenticação** – Suportar outros provedores (ex: Azure B2B).
+
+Atualize os números de issue quando forem criados para permitir o acompanhamento do progresso.


### PR DESCRIPTION
## Summary
- migrate the "A fazer" section into a roadmap
- link tasks to GitHub issues (placeholder links)
- document roadmap details in `docs/roadmap.md`

## Testing
- `pnpm test`
- `gh issue create` *(fails: requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68504516df6483329a869806002118cc