### PR TITLE
Add login callback API for core

### DIFF
--- a/apps/core/src/authConfig.ts
+++ b/apps/core/src/authConfig.ts
@@ -2,5 +2,6 @@ export const authConfig = {
   clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID || '',
   tenantId: process.env.NEXT_PUBLIC_AZURE_TENANT_ID || '',
   redirectUri:
-    process.env.NEXT_PUBLIC_REDIRECT_URI || 'http://localhost:3000/core'
+    process.env.NEXT_PUBLIC_REDIRECT_URI ||
+    'http://localhost:3000/api/login-callback'
 };

--- a/apps/core/src/pages/api/login-callback.ts
+++ b/apps/core/src/pages/api/login-callback.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PublicClientApplication } from '@azure/msal-browser';
+import { authConfig } from '../../authConfig';
+
+const msalInstance = new PublicClientApplication({
+  auth: {
+    clientId: authConfig.clientId,
+    authority: `https://login.microsoftonline.com/${authConfig.tenantId}`,
+    redirectUri: authConfig.redirectUri
+  }
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const result = await msalInstance.handleRedirectPromise();
+    if (result && result.accessToken) {
+      res.setHeader(
+        'Set-Cookie',
+        `AuthSession=${result.accessToken}; HttpOnly; Secure; Path=/`
+      );
+      res.writeHead(302, { Location: '/landing' });
+      res.end();
+    } else {
+      res.status(401).json({ error: 'Authentication failed' });
+    }
+  } catch (error) {
+    console.error('Login callback error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}

--- a/apps/core/src/pages/index.tsx
+++ b/apps/core/src/pages/index.tsx
@@ -9,7 +9,7 @@ export default function Home() {
 
   useEffect(() => {
     if (!instance.getActiveAccount()) {
-      instance.loginRedirect(loginRequest);
+      instance.loginRedirect({ ...loginRequest, redirectUri: '/api/login-callback' });
     } else {
       router.replace('/apps');
     }


### PR DESCRIPTION
## Summary
- update MSAL redirect to /api/login-callback
- create login-callback API endpoint to store AuthSession cookie
- send user through new redirect path during login

## Testing
- `pnpm lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685046172440833291c782f56288acb9