### PR TITLE
Implement login callback API

### DIFF
--- a/apps/core/src/pages/api/login-callback.ts
+++ b/apps/core/src/pages/api/login-callback.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { msalInstance } from '../../../../../lib/auth/msal';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const result = await msalInstance.handleRedirectPromise();
+    if (!result || !result.account) {
+      return res.status(400).json({ message: 'Authentication failed' });
+    }
+
+    msalInstance.setActiveAccount(result.account);
+
+    res.setHeader(
+      'Set-Cookie',
+      `AuthSession=${result.accessToken}; HttpOnly; Secure; Path=/; SameSite=Lax`
+    );
+    res.writeHead(302, { Location: '/landing' });
+    res.end();
+  } catch (err: any) {
+    res.status(500).json({ message: err.message });
+  }
+}

--- a/apps/core/src/utils/authRequest.ts
+++ b/apps/core/src/utils/authRequest.ts
@@ -1,3 +1,4 @@
 export const loginRequest = {
-  scopes: [process.env.NEXT_PUBLIC_API_SCOPES || '']
+  scopes: [process.env.NEXT_PUBLIC_API_SCOPES || ''],
+  redirectUri: '/api/login-callback'
 };


### PR DESCRIPTION
## Summary
- add `/api/login-callback` endpoint in Core app
- configure login request to redirect to the new API callback

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6850453156248332bbe4fcbcab3d900e