### PR TITLE
Fix merge artifacts in testing guide

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -42,12 +42,5 @@ Para acompanhar em modo watch utilize `pnpm test:watch`.
 Um teste simples da biblioteca UI encontra‑se em `packages/ui/src/components/__tests__/button.test.tsx`.
 Use-o como referência para novos componentes e páginas.
 
-<<<<<<< 9footc-codex/preparar-ambiente-de-testes-e-documentar
 Cada micro-serviço também possui um teste de **smoke** em `src/__tests__/home.test.tsx`,
 útil para validação rápida do carregamento da página inicial.
-
-=======
-
-Cada micro-serviço também possui um teste de **smoke** em `src/__tests__/home.test.tsx`,
-útil para validação rápida do carregamento da página inicial.
->>>>>>> CodexDev


### PR DESCRIPTION
## Summary
- clean up merge conflict markers in `docs/testing-guide.md`
- keep a single paragraph describing smoke tests

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68504a3ad00c8332b37e9d3523d4f274