### PR TITLE
Add Next.js build dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Ignora pastas de build comuns
 **/dist/
 **/build/
+**/.next/
 
 # Logs
 **/npm-debug.log*


### PR DESCRIPTION
## Summary
- ignore `.next` directories

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504a3bdf608332bf5f360436903404