### PR TITLE
Add publish config and workflow for UI package

### DIFF
--- a/.github/workflows/publish-ui.yml
+++ b/.github/workflows/publish-ui.yml
@@ -1,0 +1,25 @@
+name: Publish UI
+
+on:
+  push:
+    tags:
+      - 'ui-v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: 'https://npm.pkg.github.com'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build -F @RFWebApp/ui
+      - run: pnpm --filter @RFWebApp/ui publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@rfwebapp/ui",
   "version": "0.1.0",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GimMarSil/rf-web-platform.git",
+    "directory": "packages/ui"
+  },
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
## Summary
- configure `@rfwebapp/ui` package with `publishConfig` and repository metadata
- add GitHub Actions workflow to publish `@RFWebApp/ui` on tags

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504a5d0fdc83329c7254447bbd9179