### PR TITLE
Add Tailwind token export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ pnpm dev -F core
 | pnpm build -F @RFWebApp/ui | Build do pacote de UI |
 | pnpm run dev -F @RFWebApp/ui | Dev mode do pacote UI |
 | pnpm add -F autos @RFWebApp/ui | Adiciona o pacote UI ao microserviço |
+| pnpm run tokens -F @RFWebApp/ui | Exporta cores e espaçamentos do Tailwind |
 
 🎨 UI Partilhada: @RFWebApp/ui
 Biblioteca central de componentes estilizados com Tailwind CSS, GSAP e design Ramos Ferreira.
@@ -110,6 +111,12 @@ export default {
   presets: [preset],
   content: ['./src/**/*.{js,ts,jsx,tsx}']
 };
+```
+
+Para exportar as cores e espaçamentos configurados, execute:
+
+```bash
+pnpm run tokens -F @RFWebApp/ui
 ```
 
 🌗 Sistema de temas

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,8 @@
   "types": "src/index.ts",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "tokens": "ts-node ./scripts/export-tokens.js"
   },
   "dependencies": {
     "gsap": "^3.13.0",
@@ -24,6 +25,7 @@
     "lucide-react": "^0.510.0"
   },
   "devDependencies": {
-    "@types/react": "^19.1.8"
+    "@types/react": "^19.1.8",
+    "ts-node": "^10.9.1"
   }
 }

--- a/packages/ui/scripts/export-tokens.js
+++ b/packages/ui/scripts/export-tokens.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+require('ts-node/register');
+const fs = require('fs');
+const path = require('path');
+const resolveConfig = require('tailwindcss/resolveConfig');
+const config = require('../tailwind.config.ts').default;
+
+const full = resolveConfig(config);
+const tokens = {
+  colors: full.theme.colors,
+  spacing: full.theme.spacing
+};
+
+const output = path.join(__dirname, '..', 'tokens.json');
+fs.writeFileSync(output, JSON.stringify(tokens, null, 2));
+console.log(`Tokens gravados em ${output}`);


### PR DESCRIPTION
## Summary
- add helper script to dump Tailwind colors and spacing
- expose new `tokens` script in @rfwebapp/ui
- document token export command in README

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504a5a6ed483328644bd870660323a