### PR TITLE
Implement evaluation form API and UI

### DIFF
--- a/apps/rh/src/pages/api/evaluation/form-data/[employeeId].ts
+++ b/apps/rh/src/pages/api/evaluation/form-data/[employeeId].ts
@@ -1,0 +1,132 @@
+import { NextApiResponse } from 'next';
+import { withAuth, AuthenticatedRequest } from '../../../../middleware/auth';
+import { executeQuery } from '../../../../lib/db/pool';
+
+interface CriterionData {
+  id: number;
+  name: string;
+  description: string | null;
+  weight: string;
+  self_achievement_percentage?: number | null;
+  self_comments?: string | null;
+  manager_achievement_percentage?: number | null;
+  manager_comments?: string | null;
+}
+
+async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).json({ message: `Method ${req.method} Not Allowed` });
+  }
+
+  const { employeeId } = req.query;
+  if (!employeeId || Array.isArray(employeeId)) {
+    return res.status(400).json({ message: 'Valid employeeId required' });
+  }
+
+  const managerId = req.headers['x-selected-employee-id'] as string;
+  if (!managerId) {
+    return res.status(400).json({ message: 'Manager employee ID header missing' });
+  }
+
+  try {
+    // Get active matrix assigned to employee
+    const matrixRes = await executeQuery(
+      `SELECT m.id, m.title
+         FROM evaluation_matrix_applicability ema
+         JOIN evaluation_matrices m ON ema.matrix_id = m.id
+        WHERE ema.employee_id = $1
+          AND ema.status = 'active'
+        ORDER BY ema.valid_from DESC
+        LIMIT 1`,
+      [employeeId]
+    );
+
+    if (matrixRes.length === 0) {
+      return res.status(404).json({ message: 'No active matrix found for employee' });
+    }
+
+    const matrix = matrixRes[0];
+
+    // existing employee evaluation (by manager)
+    const evalRes = await executeQuery(
+      `SELECT id, status
+         FROM employee_evaluations
+        WHERE employee_id = $1
+          AND evaluator_id = $2
+          AND matrix_id = $3
+        ORDER BY created_at DESC
+        LIMIT 1`,
+      [employeeId, managerId, matrix.id]
+    );
+
+    const evaluation = evalRes[0] || null;
+
+    // self evaluation submitted
+    const selfEvalRes = await executeQuery(
+      `SELECT id
+         FROM self_evaluations
+        WHERE employee_id = $1
+          AND matrix_id = $2
+          AND status = 'submitted'
+        ORDER BY created_at DESC
+        LIMIT 1`,
+      [employeeId, matrix.id]
+    );
+    const selfEvalId = selfEvalRes[0]?.id;
+
+    const selfScores = selfEvalId
+      ? await executeQuery(
+          'SELECT criterion_id, achievement_percentage, employee_criterion_comments FROM self_evaluation_scores WHERE self_evaluation_id = $1',
+          [selfEvalId]
+        )
+      : [];
+
+    const selfMap = new Map(selfScores.map((s) => [s.criterion_id, s]));
+
+    const managerScores = evaluation
+      ? await executeQuery(
+          'SELECT criterion_id, achievement_percentage, manager_criterion_comments FROM evaluation_criteria_scores WHERE evaluation_id = $1',
+          [evaluation.id]
+        )
+      : [];
+    const managerMap = new Map(managerScores.map((s) => [s.criterion_id, s]));
+
+    const criteria = await executeQuery<CriterionData>(
+      'SELECT id, name, description, weight FROM evaluation_criteria WHERE matrix_id = $1 ORDER BY id',
+      [matrix.id]
+    );
+
+    const enrichedCriteria = criteria.map((c) => ({
+      ...c,
+      self_achievement_percentage: selfMap.get(c.id)?.achievement_percentage || null,
+      self_comments: selfMap.get(c.id)?.employee_criterion_comments || null,
+      manager_achievement_percentage: managerMap.get(c.id)?.achievement_percentage || null,
+      manager_comments: managerMap.get(c.id)?.manager_criterion_comments || null,
+    }));
+
+    const employeeNameRes = await executeQuery(
+      'SELECT name FROM employees WHERE id = $1',
+      [employeeId]
+    );
+
+    const response = {
+      evaluation_id: evaluation?.id || null,
+      employee_id: employeeId,
+      employee_name: employeeNameRes[0]?.name || null,
+      matrix: {
+        id: matrix.id,
+        title: matrix.title,
+        criteria: enrichedCriteria,
+      },
+      status: evaluation?.status || 'draft',
+    };
+
+    return res.status(200).json(response);
+  } catch (error) {
+    console.error('Error fetching evaluation form data:', error);
+    return res.status(500).json({ message: 'Failed to load form data' });
+  }
+}
+
+export default withAuth(handler);

--- a/apps/rh/src/pages/evaluation/evaluate/[subordinateId].tsx
+++ b/apps/rh/src/pages/evaluation/evaluate/[subordinateId].tsx
@@ -67,19 +67,15 @@ const EvaluationFormPage = () => {
       const apiClientOptions: ApiClientOptions = {
         msalInstance: instance as PublicClientApplication,
         selectedEmployeeId: managerEmployeeId, // Manager's ID is the acting user
+        interactionStatus: inProgress,
+        activeAccount: accounts[0] || null,
       };
 
       try {
         console.log(`Fetching evaluation data for subordinate: ${subordinateId}, by manager: ${managerEmployeeId}`);
-        // TODO: Replace with actual API endpoint and data structure
-        // This endpoint would need to:
-        // 1. Find or initiate an employee_evaluation for the subordinateId, managerEmployeeId, and current period/matrix.
-        // 2. Fetch the relevant evaluation_matrix and its criteria.
-        // 3. Fetch any existing self_evaluation scores and manager_evaluation scores.
-        // 4. Get subordinate's name/details.
         const fetchedData = await fetchWithAuth<SubordinateEvaluationData>(
-          `/api/evaluation/form-data/${subordinateId}`, // Placeholder API endpoint
-          { method: 'GET' }, // Potentially POST if it needs to initiate an evaluation record
+          `/api/evaluation/form-data/${subordinateId}`,
+          { method: 'GET' },
           apiClientOptions
         );
         setEvaluationData(fetchedData);
@@ -160,20 +156,47 @@ const EvaluationFormPage = () => {
                 <h3 className="text-lg font-semibold text-gray-700">{criterion.name}</h3>
                 <p className="text-sm text-gray-500 mb-1">Peso: {criterion.weight}%</p>
                 {criterion.description && <p className="text-sm text-gray-600 mb-3">{criterion.description}</p>}
-                
-                {/* TODO: Add fields for Self-Evaluation scores/comments (read-only if submitted) */}
-                {/* TODO: Add fields for Manager scores/comments */}
+
+                {/* Self-evaluation data if available */}
+                {criterion.self_achievement_percentage !== undefined && (
+                  <div className="mt-2">
+                    <label className="block text-sm font-medium text-gray-700">
+                      Autoavaliação (% Realização):
+                    </label>
+                    <input
+                      type="number"
+                      readOnly
+                      value={criterion.self_achievement_percentage ?? ''}
+                      className="mt-1 block w-full sm:w-1/2 md:w-1/3 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm bg-gray-100"
+                    />
+                  </div>
+                )}
+                {criterion.self_comments && (
+                  <div className="mt-2">
+                    <label className="block text-sm font-medium text-gray-700">
+                      Comentários do Colaborador:
+                    </label>
+                    <textarea
+                      readOnly
+                      value={criterion.self_comments}
+                      className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm bg-gray-100"
+                      rows={3}
+                    />
+                  </div>
+                )}
+
+                {/* Manager input fields */}
                 <div className="mt-2">
                   <label htmlFor={`manager_score_${criterion.id}`} className="block text-sm font-medium text-gray-700">
                     Pontuação do Gestor (% Realização):
                   </label>
-                  <input 
+                  <input
                     type="number"
                     id={`manager_score_${criterion.id}`}
                     name={`manager_score_${criterion.id}`}
                     min="0"
                     max="100"
-                    // value={...} onChange={...} 
+                    defaultValue={criterion.manager_achievement_percentage ?? ''}
                     className="mt-1 block w-full sm:w-1/2 md:w-1/3 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                     placeholder="0-100"
                   />
@@ -182,11 +205,11 @@ const EvaluationFormPage = () => {
                   <label htmlFor={`manager_comments_${criterion.id}`} className="block text-sm font-medium text-gray-700">
                     Observações do Gestor:
                   </label>
-                  <textarea 
+                  <textarea
                     id={`manager_comments_${criterion.id}`}
                     name={`manager_comments_${criterion.id}`}
                     rows={3}
-                    // value={...} onChange={...}
+                    defaultValue={criterion.manager_comments ?? ''}
                     className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                     placeholder="Comentários sobre o desempenho neste critério..."
                   />


### PR DESCRIPTION
## Summary
- implement new API endpoint for loading evaluation form data
- use the new endpoint in evaluation form page
- display self‑evaluation results and allow manager comments
- include auth options when fetching form data

## Testing
- `npm test` *(fails: jest not found)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504a3c7d788332a3f3bd8dd5b95698