### PR TITLE
Ensure autos tests use theme provider

### DIFF
--- a/apps/autos/src/__tests__/home.test.tsx
+++ b/apps/autos/src/__tests__/home.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from '@testing-library/react'
 import Home from '../pages/index'
+import { ThemeProvider } from '@RFWebApp/ui'
 
 describe('Autos Home', () => {
   it('shows Example Button', () => {
-    render(<Home />)
+    render(
+      <ThemeProvider>
+        <Home />
+      </ThemeProvider>
+    )
     expect(screen.getByRole('button', { name: 'Example Button' })).toBeInTheDocument()
   })
 })

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -44,3 +44,19 @@ Use-o como referência para novos componentes e páginas.
 
 Cada micro-serviço também possui um teste de **smoke** em `src/__tests__/home.test.tsx`,
 útil para validação rápida do carregamento da página inicial.
+
+## Componentes com contexto
+
+Alguns componentes da UI dependem de providers como `ThemeProvider`. Caso o teste
+gere erros como `usePrefs must be used within ThemeProvider`, envolva o componente
+com o provider correspondente:
+
+```tsx
+import { ThemeProvider } from '@RFWebApp/ui';
+
+render(
+  <ThemeProvider>
+    <MyComponent />
+  </ThemeProvider>
+);
+```


### PR DESCRIPTION
## Summary
- fix Autos smoke test by wrapping `Home` in `ThemeProvider`
- document how to test components that depend on context providers

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68504e9dd7808332a3acaf091b9e164c