### PR TITLE
Update home pages and smoke tests

### DIFF
--- a/apps/autos/src/__tests__/home.test.tsx
+++ b/apps/autos/src/__tests__/home.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from '@testing-library/react'
 import Home from '../pages/index'
+import { ThemeProvider } from '@RFWebApp/ui'
 
 describe('Autos Home', () => {
   it('shows Example Button', () => {
-    render(<Home />)
+    render(
+      <ThemeProvider>
+        <Home />
+      </ThemeProvider>
+    )
     expect(screen.getByRole('button', { name: 'Example Button' })).toBeInTheDocument()
   })
 })

--- a/apps/dashboards/src/__tests__/home.test.tsx
+++ b/apps/dashboards/src/__tests__/home.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react'
 import Home from '../pages/index'
 
 describe('Dashboards Home', () => {
-  it('shows Example Button', () => {
+  it('shows Dashboards app text', () => {
     render(<Home />)
-    expect(screen.getByRole('button', { name: 'Example Button' })).toBeInTheDocument()
+    expect(screen.getByText('Dashboards app')).toBeInTheDocument()
   })
 })

--- a/apps/dashboards/src/pages/index.tsx
+++ b/apps/dashboards/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { Button } from '@RFWebApp/ui';
 export default function Home() {
   return (
     <div className="p-4 space-y-2">
-      <div>$app app</div>
+      <div>Dashboards app</div>
       <Button>Example Button</Button>
     </div>
   );

--- a/apps/expenses/src/__tests__/home.test.tsx
+++ b/apps/expenses/src/__tests__/home.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react'
 import Home from '../pages/index'
 
 describe('Expenses Home', () => {
-  it('shows Example Button', () => {
+  it('shows Expenses app text', () => {
     render(<Home />)
-    expect(screen.getByRole('button', { name: 'Example Button' })).toBeInTheDocument()
+    expect(screen.getByText('Expenses app')).toBeInTheDocument()
   })
 })

--- a/apps/expenses/src/pages/index.tsx
+++ b/apps/expenses/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { Button } from '@RFWebApp/ui';
 export default function Home() {
   return (
     <div className="p-4 space-y-2">
-      <div>$app app</div>
+      <div>Expenses app</div>
       <Button>Example Button</Button>
     </div>
   );

--- a/apps/timesheet/src/__tests__/home.test.tsx
+++ b/apps/timesheet/src/__tests__/home.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react'
 import Home from '../pages/index'
 
 describe('Timesheet Home', () => {
-  it('shows Example Button', () => {
+  it('shows Timesheet app text', () => {
     render(<Home />)
-    expect(screen.getByRole('button', { name: 'Example Button' })).toBeInTheDocument()
+    expect(screen.getByText('Timesheet app')).toBeInTheDocument()
   })
 })

--- a/apps/timesheet/src/pages/index.tsx
+++ b/apps/timesheet/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { Button } from '@RFWebApp/ui';
 export default function Home() {
   return (
     <div className="p-4 space-y-2">
-      <div>$app app</div>
+      <div>Timesheet app</div>
       <Button>Example Button</Button>
     </div>
   );

--- a/apps/vendors/src/__tests__/home.test.tsx
+++ b/apps/vendors/src/__tests__/home.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react'
 import Home from '../pages/index'
 
 describe('Vendors Home', () => {
-  it('shows Example Button', () => {
+  it('shows Vendors app text', () => {
     render(<Home />)
-    expect(screen.getByRole('button', { name: 'Example Button' })).toBeInTheDocument()
+    expect(screen.getByText('Vendors app')).toBeInTheDocument()
   })
 })

--- a/apps/vendors/src/pages/index.tsx
+++ b/apps/vendors/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { Button } from '@RFWebApp/ui';
 export default function Home() {
   return (
     <div className="p-4 space-y-2">
-      <div>$app app</div>
+      <div>Vendors app</div>
       <Button>Example Button</Button>
     </div>
   );


### PR DESCRIPTION
## Summary
- display application names on home pages instead of placeholder text
- check for the new text in smoke tests
- ensure autos test renders within ThemeProvider

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68504e9d1ba08332921618b3f386e7d7