### PR TITLE
Implement MSAL auth helper in evaluation API

### DIFF
--- a/apps/rh/src/pages/api/evaluation-matrices/[matrixId]/applicability.ts
+++ b/apps/rh/src/pages/api/evaluation-matrices/[matrixId]/applicability.ts
@@ -1,24 +1,46 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
+import * as jose from 'jose';
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   ssl: { rejectUnauthorized: false },
 });
 
+// Validate bearer token and extract system user id
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
-  // TODO: Replace with actual MSAL or equivalent authentication logic
-  console.warn('Using placeholder system user ID for audit logs in matrix applicability API. Integrate actual authentication.');
-  return 'system-placeholder-user-id';
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith('Bearer ')) return null;
+  const token = auth.split(' ')[1];
+  const tenant = process.env.AZURE_AD_TENANT_ID;
+  const audience = process.env.AZURE_AD_API_AUDIENCE || process.env.AZURE_AD_CLIENT_ID;
+  if (!tenant || !audience) return null;
+  try {
+    const JWKS = jose.createRemoteJWKSet(new URL(`https://login.microsoftonline.com/${tenant}/discovery/v2.0/keys`));
+    const { payload } = await jose.jwtVerify(token, JWKS, { issuer: `https://login.microsoftonline.com/${tenant}/v2.0`, audience });
+    const id = payload.oid || payload.sub;
+    return typeof id === 'string' ? id : null;
+  } catch (err) {
+    console.error('Token validation failed', err);
+    return null;
+  }
 }
 
-async function getSelectedEmployeeId(req: NextApiRequest): Promise<string | null> {
-  const selectedEmployeeId = req.headers['x-selected-employee-id'] as string;
+async function getSelectedEmployeeId(req: NextApiRequest, userId: string): Promise<string | null> {
+  const headerValue = req.headers['x-selected-employee-id'] as string | undefined;
+  const selectedEmployeeId = headerValue || (req.body && (req.body.actingAsEmployeeId as string));
   if (!selectedEmployeeId) {
     console.warn('X-Selected-Employee-ID header not found for matrix applicability API.');
     return null;
   }
-  return selectedEmployeeId;
+  try {
+    const result = await pool.query('SELECT user_id FROM employees WHERE employee_number = $1', [selectedEmployeeId]);
+    if (result.rows.length === 0 || result.rows[0].user_id !== userId) return null;
+    return selectedEmployeeId;
+  } catch (err) {
+    console.error('Error validating selected employee', err);
+    return null;
+  }
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -38,7 +60,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ message: 'Unauthorized: Authenticated system user ID not available.' });
     }
 
-    selectedEmployeeId = await getSelectedEmployeeId(req);
+    selectedEmployeeId = await getSelectedEmployeeId(req, authenticatedSystemUserId);
     if (!selectedEmployeeId && (method === 'POST' || method === 'PUT' || method === 'DELETE')) {
       return res.status(403).json({ message: 'Forbidden: Selected Employee ID required for this operation.' });
     }

--- a/apps/rh/src/pages/api/evaluation-matrices/[matrixId]/criteria.ts
+++ b/apps/rh/src/pages/api/evaluation-matrices/[matrixId]/criteria.ts
@@ -1,24 +1,46 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Pool } from 'pg';
+import * as jose from 'jose';
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   ssl: { rejectUnauthorized: false },
 });
 
+// Validate bearer token and extract system user id
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
-  // TODO: Replace with actual MSAL or equivalent authentication logic
-  console.warn('Using placeholder system user ID for audit logs in matrix criteria API. Integrate actual authentication.');
-  return 'system-placeholder-user-id';
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith('Bearer ')) return null;
+  const token = auth.split(' ')[1];
+  const tenant = process.env.AZURE_AD_TENANT_ID;
+  const audience = process.env.AZURE_AD_API_AUDIENCE || process.env.AZURE_AD_CLIENT_ID;
+  if (!tenant || !audience) return null;
+  try {
+    const JWKS = jose.createRemoteJWKSet(new URL(`https://login.microsoftonline.com/${tenant}/discovery/v2.0/keys`));
+    const { payload } = await jose.jwtVerify(token, JWKS, { issuer: `https://login.microsoftonline.com/${tenant}/v2.0`, audience });
+    const id = payload.oid || payload.sub;
+    return typeof id === 'string' ? id : null;
+  } catch (err) {
+    console.error('Token validation failed', err);
+    return null;
+  }
 }
 
-async function getSelectedEmployeeId(req: NextApiRequest): Promise<string | null> {
-  const selectedEmployeeId = req.headers['x-selected-employee-id'] as string;
+async function getSelectedEmployeeId(req: NextApiRequest, userId: string): Promise<string | null> {
+  const headerValue = req.headers['x-selected-employee-id'] as string | undefined;
+  const selectedEmployeeId = headerValue || (req.body && (req.body.actingAsEmployeeId as string));
   if (!selectedEmployeeId) {
     console.warn('X-Selected-Employee-ID header not found for matrix criteria API.');
     return null;
   }
-  return selectedEmployeeId;
+  try {
+    const result = await pool.query('SELECT user_id FROM employees WHERE employee_number = $1', [selectedEmployeeId]);
+    if (result.rows.length === 0 || result.rows[0].user_id !== userId) return null;
+    return selectedEmployeeId;
+  } catch (err) {
+    console.error('Error validating selected employee', err);
+    return null;
+  }
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -38,7 +60,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ message: 'Unauthorized: Authenticated system user ID not available.' });
     }
 
-    selectedEmployeeId = await getSelectedEmployeeId(req);
+    selectedEmployeeId = await getSelectedEmployeeId(req, authenticatedSystemUserId);
     if (!selectedEmployeeId && (method === 'POST' || method === 'PUT' || method === 'DELETE')) {
       return res.status(403).json({ message: 'Forbidden: Selected Employee ID required for this operation.' });
     }


### PR DESCRIPTION
## Summary
- add MSAL-style JWT verification helper on evaluation API endpoints
- validate selected employee id via DB lookup
- replace placeholder system user id with real one

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504e9978f083329448342ae7fe778f