### PR TITLE
Add lib package alias

### DIFF
--- a/apps/autos/next.config.js
+++ b/apps/autos/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@rfwebapp/ui']
+  transpilePackages: ['@rfwebapp/ui', '@rfwebapp/lib']
 };
 
 module.exports = nextConfig;

--- a/apps/autos/src/pages/_app.tsx
+++ b/apps/autos/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
 import { ThemeProvider } from '@RFWebApp/ui';
-import { useAnalytics } from '../../../lib/useAnalytics';
+import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
   auth: {

--- a/apps/core/next.config.js
+++ b/apps/core/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@rfwebapp/ui']
+  transpilePackages: ['@rfwebapp/ui', '@rfwebapp/lib']
 };
 
 module.exports = nextConfig;

--- a/apps/core/src/pages/apps.tsx
+++ b/apps/core/src/pages/apps.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AppCard } from '@RFWebApp/ui';
-import { useRequireAuth } from '../../../lib/useRequireAuth';
+import { useRequireAuth } from '@rfwebapp/lib/useRequireAuth';
 
 export default function AppsPage() {
   const employee = useRequireAuth();

--- a/apps/core/src/pages/select-employee.tsx
+++ b/apps/core/src/pages/select-employee.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useState } from 'react';
-import { useAuthStore } from '../../../lib/useAuthStore';
+import { useAuthStore } from '@rfwebapp/lib/useAuthStore';
 import { useRouter } from 'next/router';
 
 export default function SelectEmployee() {

--- a/apps/dashboards/next.config.js
+++ b/apps/dashboards/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@rfwebapp/ui']
+  transpilePackages: ['@rfwebapp/ui', '@rfwebapp/lib']
 };
 
 module.exports = nextConfig;

--- a/apps/dashboards/src/pages/_app.tsx
+++ b/apps/dashboards/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
 import { ThemeProvider } from '@RFWebApp/ui';
-import { useAnalytics } from '../../../lib/useAnalytics';
+import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
   auth: {

--- a/apps/expenses/next.config.js
+++ b/apps/expenses/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@rfwebapp/ui']
+  transpilePackages: ['@rfwebapp/ui', '@rfwebapp/lib']
 };
 
 module.exports = nextConfig;

--- a/apps/expenses/src/pages/_app.tsx
+++ b/apps/expenses/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
 import { ThemeProvider } from '@RFWebApp/ui';
-import { useAnalytics } from '../../../lib/useAnalytics';
+import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
   auth: {

--- a/apps/inventory/next.config.js
+++ b/apps/inventory/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@rfwebapp/ui']
+  transpilePackages: ['@rfwebapp/ui', '@rfwebapp/lib']
 };
 
 module.exports = nextConfig;

--- a/apps/inventory/src/pages/_app.tsx
+++ b/apps/inventory/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
 import { ThemeProvider } from '@RFWebApp/ui';
-import { useAnalytics } from '../../../lib/useAnalytics';
+import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
   auth: {

--- a/apps/rh/export-schema.ts
+++ b/apps/rh/export-schema.ts
@@ -2,7 +2,7 @@ import { Pool } from 'pg';
 import * as fs from 'fs';
 
 // Load environment variables from .env.local
-import '../../lib/loadEnv.js';
+import '@rfwebapp/lib/loadEnv.js';
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,

--- a/apps/rh/next.config.js
+++ b/apps/rh/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@rfwebapp/ui']
+  transpilePackages: ['@rfwebapp/ui', '@rfwebapp/lib']
 };
 
 module.exports = nextConfig;

--- a/apps/rh/src/pages/_app.tsx
+++ b/apps/rh/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../config/authConfig';
 import '../styles/globals.css';
 import { ThemeProvider } from '@RFWebApp/ui';
-import { useAnalytics } from '../../../lib/useAnalytics';
+import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 import { FuncionarioProvider } from '../context/FuncionarioContext';
 import { SelectedEmployeeProvider } from '@/contexts/SelectedEmployeeContext';
 import 'react-toastify/dist/ReactToastify.css';

--- a/apps/rh/src/pages/api/create-postgres-tables.js
+++ b/apps/rh/src/pages/api/create-postgres-tables.js
@@ -1,5 +1,5 @@
 // Load environment variables from .env.local
-require('../../../../../lib/loadEnv.js');
+require('@rfwebapp/lib/loadEnv.js');
 const { Client } = require('pg');
 
 // Configuração Postgres (Railway)

--- a/apps/rh/src/pages/api/syncEmployees.js
+++ b/apps/rh/src/pages/api/syncEmployees.js
@@ -8,7 +8,7 @@
  *************************************************************/
 
 // Load environment variables from .env.local
-require('../../../../../lib/loadEnv.js');
+require('@rfwebapp/lib/loadEnv.js');
 const sql = require('mssql');
 const { Client } = require('pg');
 

--- a/apps/timesheet/next.config.js
+++ b/apps/timesheet/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@rfwebapp/ui']
+  transpilePackages: ['@rfwebapp/ui', '@rfwebapp/lib']
 };
 
 module.exports = nextConfig;

--- a/apps/timesheet/src/pages/_app.tsx
+++ b/apps/timesheet/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
 import { ThemeProvider } from '@RFWebApp/ui';
-import { useAnalytics } from '../../../lib/useAnalytics';
+import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
   auth: {

--- a/apps/vendors/next.config.js
+++ b/apps/vendors/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@rfwebapp/ui']
+  transpilePackages: ['@rfwebapp/ui', '@rfwebapp/lib']
 };
 
 module.exports = nextConfig;

--- a/apps/vendors/src/pages/_app.tsx
+++ b/apps/vendors/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
 import { ThemeProvider } from '@RFWebApp/ui';
-import { useAnalytics } from '../../../lib/useAnalytics';
+import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
   auth: {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@RFWebApp/ui": ["packages/ui/src"]
+      "@RFWebApp/ui": ["packages/ui/src"],
+      "@rfwebapp/lib": ["packages/lib"]
     },
     "target": "ES2020",
     "module": "ESNext",


### PR DESCRIPTION
## Summary
- add `@rfwebapp/lib` alias in `tsconfig.base.json`
- transpile lib package in each Next.js app
- import lib modules via alias instead of relative paths

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_685052f017308332ab35ddb6a65efa23