### PR TITLE
Remove npm lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 .vscode/
 .idea/
 .DS_Store
+
+# Ignore npm lock files to rely solely on pnpm-lock.yaml
+**/package-lock.json


### PR DESCRIPTION
## Summary
- ignore package-lock.json so the repo relies exclusively on `pnpm-lock.yaml`

## Testing
- `pnpm lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6850563b2da48332b796d7329405a79f