### PR TITLE
Fix build issue with ThemeProvider

### DIFF
--- a/apps/core/src/pages/_app.tsx
+++ b/apps/core/src/pages/_app.tsx
@@ -18,11 +18,13 @@ const msalInstance = new PublicClientApplication({
 function MyApp({ Component, pageProps }: AppProps) {
   useAnalytics('core');
   return (
-    <ThemeProvider>
-      <MsalProvider instance={msalInstance}>
-        <Component {...pageProps} />
-      </MsalProvider>
-    </ThemeProvider>
+    <ThemeProvider
+      children={
+        <MsalProvider instance={msalInstance}>
+          <Component {...pageProps} />
+        </MsalProvider>
+      }
+    />
   );
 }
 

--- a/apps/core/src/pages/api/login-callback.ts
+++ b/apps/core/src/pages/api/login-callback.ts
@@ -1,24 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { msalInstance } from '../../../../lib/auth/msal';
-
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
-  try {
-    const response = await msalInstance.handleRedirectPromise();
-    const token = response?.accessToken;
-    if (token) {
-      res.setHeader(
-        'Set-Cookie',
-        `AuthSession=${token}; HttpOnly; Path=/; Secure`
-      );
-      res.writeHead(302, { Location: '/landing' });
-      res.end();
-    } else {
-      res.status(400).json({ message: 'No token found' });
-    }
-=======
 import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../../authConfig';
 
@@ -47,3 +27,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.setHeader('Set-Cookie', `AuthSession=${token}; HttpOnly; Path=/; Secure; SameSite=Lax`);
     res.writeHead(302, { Location: '/landing' });
     res.end();
+  } catch (error) {
+    res.status(500).json({ message: 'Error processing callback' });
+  }
+}

--- a/apps/core/src/pages/apps.tsx
+++ b/apps/core/src/pages/apps.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AppCard } from '@RFWebApp/ui';
-import { useRequireAuth } from '../../../lib/useRequireAuth';
+import { useRequireAuth } from '../../../../lib/useRequireAuth';
 
 export default function AppsPage() {
   const employee = useRequireAuth();

--- a/packages/ui/src/components/theme-provider.tsx
+++ b/packages/ui/src/components/theme-provider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState, type FC, type ReactNode } from 'react';
 
 export type Theme = 'light' | 'dark' | 'high-contrast';
 
@@ -11,7 +11,11 @@ interface PrefContextValue {
 
 const PrefContext = createContext<PrefContextValue | undefined>(undefined);
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider: FC<ThemeProviderProps> = ({ children }) => {
   const [theme, setThemeState] = useState<Theme>('light');
   const [language, setLanguageState] = useState('pt');
 


### PR DESCRIPTION
## Summary
- update ThemeProvider to explicit FC with props
- adjust ThemeProvider usage in Core app
- fix relative import for useRequireAuth
- resolve merge conflict in login callback handler

## Testing
- `pnpm test`
- `pnpm --filter core build` *(fails: Cannot find module '../../../lib/useRequireAuth')*


------
https://chatgpt.com/codex/tasks/task_e_685059df81d88332b43a89f71218e86a