### PR TITLE
Use JSX children for ThemeProvider

### DIFF
--- a/apps/core/src/pages/_app.tsx
+++ b/apps/core/src/pages/_app.tsx
@@ -18,13 +18,11 @@ const msalInstance = new PublicClientApplication({
 function MyApp({ Component, pageProps }: AppProps) {
   useAnalytics('core');
   return (
-    <ThemeProvider
-      children={
-        <MsalProvider instance={msalInstance}>
-          <Component {...pageProps} />
-        </MsalProvider>
-      }
-    />
+    <ThemeProvider>
+      <MsalProvider instance={msalInstance}>
+        <Component {...pageProps} />
+      </MsalProvider>
+    </ThemeProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- adjust `_app.tsx` in the core app to nest children directly in `ThemeProvider`

## Testing
- `pnpm --filter core build` *(fails: Property 'children' is missing in type '{}' but required in type 'ThemeProviderProps')*

------
https://chatgpt.com/codex/tasks/task_e_6850600e493c83329e37b54116f6a137