### PR TITLE
Remove JS loadEnv and update imports

### DIFF
--- a/apps/rh/export-schema.ts
+++ b/apps/rh/export-schema.ts
@@ -2,7 +2,7 @@ import { Pool } from 'pg';
 import * as fs from 'fs';
 
 // Load environment variables from .env.local
-import '../../lib/loadEnv.js';
+import '../../lib/loadEnv.ts';
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,

--- a/apps/rh/src/pages/api/create-postgres-tables.js
+++ b/apps/rh/src/pages/api/create-postgres-tables.js
@@ -1,5 +1,5 @@
 // Load environment variables from .env.local
-require('../../../../../lib/loadEnv.js');
+require('../../../../../lib/loadEnv.ts');
 const { Client } = require('pg');
 
 // Configuração Postgres (Railway)

--- a/apps/rh/src/pages/api/syncEmployees.js
+++ b/apps/rh/src/pages/api/syncEmployees.js
@@ -8,7 +8,7 @@
  *************************************************************/
 
 // Load environment variables from .env.local
-require('../../../../../lib/loadEnv.js');
+require('../../../../../lib/loadEnv.ts');
 const sql = require('mssql');
 const { Client } = require('pg');
 

--- a/lib/loadEnv.js
+++ b/lib/loadEnv.js
@@ -1,2 +1,0 @@
-const dotenv = require('dotenv');
-dotenv.config({ path: '.env.local' });


### PR DESCRIPTION
## Summary
- remove the compiled JS version of `loadEnv`
- point scripts to use `loadEnv.ts` instead of `loadEnv.js`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685177c432948332b82f5a3054c88d62