### PR TITLE
Disable react-in-jsx-scope and autodetect React

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,9 +20,15 @@ export default [
       '@typescript-eslint': eslintPluginTs,
       react: reactPlugin
     },
+    settings: {
+      react: {
+        version: 'detect'
+      }
+    },
     rules: {
       ...reactPlugin.configs.recommended.rules,
-      ...eslintPluginTs.configs.recommended.rules
+      ...eslintPluginTs.configs.recommended.rules,
+      'react/react-in-jsx-scope': 'off'
     }
   }
 ];


### PR DESCRIPTION
## Summary
- configure eslint-plugin-react to automatically detect the React version
- disable the obsolete `react/react-in-jsx-scope` rule for React 17+

## Testing
- `pnpm lint` *(fails: 1585 problems)*

------
https://chatgpt.com/codex/tasks/task_e_685177cee49c83328aa41527dd316a0f