### PR TITLE
Cleanup analytics API logs

### DIFF
--- a/apps/autos/src/pages/api/analytics.ts
+++ b/apps/autos/src/pages/api/analytics.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logAnalytics } from '../../../../../lib/logger';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  console.log('Autos analytics:', req.body);
+  logAnalytics('autos', req.body);
   res.status(200).json({ ok: true });
 }

--- a/apps/core/src/pages/api/analytics.ts
+++ b/apps/core/src/pages/api/analytics.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logAnalytics } from '../../../../../lib/logger';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  console.log('Core analytics:', req.body);
+  logAnalytics('core', req.body);
   res.status(200).json({ ok: true });
 }

--- a/apps/dashboards/src/pages/api/analytics.ts
+++ b/apps/dashboards/src/pages/api/analytics.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logAnalytics } from '../../../../../lib/logger';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  console.log('dashboards analytics:', req.body);
+  logAnalytics('dashboards', req.body);
   res.status(200).json({ ok: true });
 }

--- a/apps/expenses/src/pages/api/analytics.ts
+++ b/apps/expenses/src/pages/api/analytics.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logAnalytics } from '../../../../../lib/logger';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  console.log('expenses analytics:', req.body);
+  logAnalytics('expenses', req.body);
   res.status(200).json({ ok: true });
 }

--- a/apps/inventory/src/pages/api/analytics.ts
+++ b/apps/inventory/src/pages/api/analytics.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logAnalytics } from '../../../../../lib/logger';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  console.log('Inventory analytics:', req.body);
+  logAnalytics('inventory', req.body);
   res.status(200).json({ ok: true });
 }

--- a/apps/rh/src/pages/api/analytics.ts
+++ b/apps/rh/src/pages/api/analytics.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logAnalytics } from '../../../../../lib/logger';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  console.log('RH analytics:', req.body);
+  logAnalytics('rh', req.body);
   res.status(200).json({ ok: true });
 }

--- a/apps/timesheet/src/pages/api/analytics.ts
+++ b/apps/timesheet/src/pages/api/analytics.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logAnalytics } from '../../../../../lib/logger';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  console.log('timesheet analytics:', req.body);
+  logAnalytics('timesheet', req.body);
   res.status(200).json({ ok: true });
 }

--- a/apps/vendors/src/pages/api/analytics.ts
+++ b/apps/vendors/src/pages/api/analytics.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { logAnalytics } from '../../../../../lib/logger';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  console.log('vendors analytics:', req.body);
+  logAnalytics('vendors', req.body);
   res.status(200).json({ ok: true });
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,18 @@
+import fs from 'fs';
+import path from 'path';
+
+const logFile = path.join(process.cwd(), 'logs', 'analytics.log');
+
+export function logAnalytics(service: string, payload: unknown): void {
+  try {
+    fs.mkdirSync(path.dirname(logFile), { recursive: true });
+    const entry = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      service,
+      payload
+    });
+    fs.appendFileSync(logFile, entry + '\n');
+  } catch {
+    // Ignore logging errors
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a simple file logger
- use the new logger in every analytics API handler

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685177d0738483328300f0975adee582