### PR TITLE
Add pnpm test step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,16 @@ jobs:
           node-version: 18
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+      - name: Cache Jest results
+        uses: actions/cache@v3
+        with:
+          path: |
+            **/node_modules/.cache/jest
+          key: ${{ runner.os }}-jest-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-jest-
       - run: pnpm lint
+      - run: pnpm test
       - run: pnpm --filter ${{ matrix.app }} build
       - name: Deploy
         run: echo "Deploy ${{ matrix.app }} to your hosting platform"


### PR DESCRIPTION
## Summary
- run `pnpm test` in CI after linting
- cache Jest results for faster workflows

## Testing
- `pnpm install`
- `pnpm lint` *(fails: eslint errors)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6851806f42688332a424c0f35658bfa6