### PR TITLE
Update UI release workflow and docs

### DIFF
--- a/.github/workflows/publish-ui.yml
+++ b/.github/workflows/publish-ui.yml
@@ -19,7 +19,11 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build -F @RFWebApp/ui
-      - run: pnpm --filter @RFWebApp/ui publish --no-git-checks
+      - name: Set version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#ui-v}" >> $GITHUB_ENV
+      - run: pnpm version "$VERSION" -w @rfwebapp/ui --no-git-tag-version
+      - run: pnpm lint && pnpm test
+      - run: pnpm build -F @rfwebapp/ui
+      - run: pnpm --filter @rfwebapp/ui publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,15 @@
+# @RFWebApp/ui
+
+Biblioteca de componentes React compartilhada para as aplicações do monorepo.
+
+## Processo de release
+
+1. Certifique-se de que todas as mudanças estejam na branch `main`.
+2. Crie e envie uma tag com o formato `ui-v<versao>` (ex.: `ui-v1.2.0`).
+   A publicação é iniciada quando a tag é enviada para o GitHub.
+3. O workflow **Publish UI** será executado automaticamente e irá:
+   - Atualizar `packages/ui/package.json` com `pnpm version` usando o número da tag;
+   - Executar `pnpm lint` e `pnpm test`;
+   - Buildar e publicar o pacote no registro definido em `publishConfig.registry`.
+
+Não é necessário publicar manualmente: apenas envie a tag e aguarde o workflow.


### PR DESCRIPTION
## Summary
- update `publish-ui.yml` to lint, test and bump version from tag
- add README with release instructions for `@RFWebApp/ui`

## Testing
- `pnpm lint` *(fails: no-empty-object-type etc.)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6851806925308332903c4425003ce7a4