### PR TITLE
Add Postgres integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,39 @@ on:
     branches: [main]
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/testdb
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+
   build:
     runs-on: ubuntu-latest
+    needs: test
     strategy:
       matrix:
         app: [core, autos, rh, inventory]

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -60,3 +60,15 @@ render(
   </ThemeProvider>
 );
 ```
+
+## Testes de integra\u00e7\u00e3o com Postgres
+
+Alguns testes em `lib/db/__tests__` verificam a integra\u00e7\u00e3o com uma inst\u00e2ncia Postgres. Para execut\u00e1-los localmente, inicie um cont\u00eainer e defina a vari\u00e1vel `DATABASE_URL`:
+
+```bash
+docker run --name rf-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres:latest
+export DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
+pnpm test
+```
+
+O cont\u00eainer pode ser removido ap\u00f3s os testes com `docker rm -f rf-postgres`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     '<rootDir>/apps/inventory',
     '<rootDir>/apps/rh',
     '<rootDir>/apps/timesheet',
-    '<rootDir>/apps/vendors'
+    '<rootDir>/apps/vendors',
+    '<rootDir>/lib'
   ]
 }

--- a/lib/db/__tests__/pool.integration.test.ts
+++ b/lib/db/__tests__/pool.integration.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+import { executeQuery, executeTransaction } from '../pool'
+
+const TABLE = 'integration_test_numbers'
+
+beforeAll(async () => {
+  await executeQuery(`CREATE TABLE IF NOT EXISTS ${TABLE} (value INT)`)
+  await executeQuery(`TRUNCATE TABLE ${TABLE}`)
+})
+
+afterAll(async () => {
+  await executeQuery(`DROP TABLE IF EXISTS ${TABLE}`)
+})
+
+describe('executeQuery', () => {
+  it('runs a simple select', async () => {
+    const result = await executeQuery<{ result: number }>('SELECT 1 + 1 AS result')
+    expect(result[0].result).toBe(2)
+  })
+})
+
+describe('executeTransaction', () => {
+  beforeEach(async () => {
+    await executeQuery(`TRUNCATE TABLE ${TABLE}`)
+  })
+
+  it('commits the transaction', async () => {
+    await executeTransaction(async (client) => {
+      await executeQuery(`INSERT INTO ${TABLE} (value) VALUES ($1)`, [42], client)
+    })
+    const rows = await executeQuery<{ value: number }>(`SELECT value FROM ${TABLE}`)
+    expect(rows).toEqual([{ value: 42 }])
+  })
+
+  it('rolls back on error', async () => {
+    await expect(
+      executeTransaction(async (client) => {
+        await executeQuery(`INSERT INTO ${TABLE} (value) VALUES ($1)`, [7], client)
+        throw new Error('fail')
+      })
+    ).rejects.toThrow('fail')
+    const rows = await executeQuery<{ value: number }>(`SELECT value FROM ${TABLE} WHERE value = 7`)
+    expect(rows.length).toBe(0)
+  })
+})

--- a/lib/db/pool.ts
+++ b/lib/db/pool.ts
@@ -19,7 +19,7 @@ export const pool = new Pool({
 });
 
 // Handle pool errors
-pool.on('error', (err) => {
+pool.on('error', (err: Error) => {
   console.error('Unexpected error on idle client', err);
   process.exit(-1);
 });

--- a/lib/jest.config.js
+++ b/lib/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  setupFilesAfterEnv: ['<rootDir>/../jest.setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/../tsconfig.base.json'
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "prettier": "^3.5.3",
     "rimraf": "^5.0.10",
     "tailwindcss": "^4.1.10",
-    "ts-jest": "^29.3.2"
+    "ts-jest": "^29.3.2",
+    "pg": "^8.16.0",
+    "@types/pg": "^8.6.6"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
+      '@types/pg':
+        specifier: ^8.6.6
+        version: 8.15.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.34.0
         version: 8.34.0(@typescript-eslint/parser@8.34.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
@@ -57,6 +60,9 @@ importers:
       next:
         specifier: 14.1.0
         version: 14.1.0(@babel/core@7.27.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      pg:
+        specifier: ^8.16.0
+        version: 8.16.0
       postcss:
         specifier: ^8.4.35
         version: 8.5.5
@@ -1814,6 +1820,9 @@ packages:
 
   '@types/node@24.0.2':
     resolution: {integrity: sha512-Kv1shWMfCUnzbQTosAHrF2p8AzccoLODqJ0XqGPRA/mGVZR86KCk8I+fyh6B5+kcLtAKS9BquXUxVO79jU9UGg==}
+
+  '@types/pg@8.15.4':
+    resolution: {integrity: sha512-I6UNVBAoYbvuWkkU3oosC8yxqH21f4/Jc4DK71JLG3dT2mdlGe1z+ep/LQGXaKaOgcvUrsQoPRqfgtMcvZiJhg==}
 
   '@types/raf@3.4.3':
     resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
@@ -6938,6 +6947,12 @@ snapshots:
   '@types/node@24.0.2':
     dependencies:
       undici-types: 7.8.0
+
+  '@types/pg@8.15.4':
+    dependencies:
+      '@types/node': 24.0.2
+      pg-protocol: 1.10.0
+      pg-types: 2.2.0
 
   '@types/raf@3.4.3':
     optional: true


### PR DESCRIPTION
## Summary
- integrate lib into Jest projects
- document how to run Postgres integration tests
- add Postgres service to CI
- implement executeQuery/executeTransaction integration tests
- setup Jest config for `lib`
- ensure Pool error handler typed
- install pg and @types/pg

## Testing
- `pnpm test` *(fails: DATABASE_URL environment variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_6851807068b48332b79d058e2f2bdbc9