### PR TITLE
Add logger utilities and refactor API handlers

### DIFF
--- a/apps/rh/src/__tests__/logger.test.ts
+++ b/apps/rh/src/__tests__/logger.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'fs';
+import * as logger from '../../../../lib/logger';
+
+describe('logger utils', () => {
+  const appendSpy = jest.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+  const mkdirSpy = jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+
+  afterEach(() => {
+    appendSpy.mockClear();
+    mkdirSpy.mockClear();
+  });
+
+  it('masks sensitive fields', () => {
+    logger.info('test message', {
+      password: 'secret',
+      token: 'abcd',
+      normal: 'ok'
+    });
+    expect(appendSpy).toHaveBeenCalled();
+    const logged = JSON.parse(appendSpy.mock.calls[0][1]);
+    expect(logged.level).toBe('info');
+    expect(logged.meta.password).toBe('***');
+    expect(logged.meta.token).toBe('***');
+    expect(logged.meta.normal).toBe('ok');
+  });
+});

--- a/apps/rh/src/pages/api/recruitment-create-table.ts
+++ b/apps/rh/src/pages/api/recruitment-create-table.ts
@@ -1,4 +1,5 @@
 import pool from '../../lib/dbPool';
+import { info, error as logError } from '../../../lib/logger';
 
 
 export default async function handler(req, res) {
@@ -131,7 +132,7 @@ export default async function handler(req, res) {
     await client.query('BEGIN'); // Start transaction
 
     await client.query(schemaManagementQueries);
-    console.log('Schema for recruitment, logs, and admission tables verified/updated.');
+    info('Schema for recruitment, logs, and admission tables verified/updated.');
 
     // Create candidates table separately
     await client.query(`
@@ -162,7 +163,7 @@ export default async function handler(req, res) {
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       );
     `);
-    console.log('Ensured candidates table exists.');
+    info('Ensured candidates table exists.');
 
     await client.query(`
       CREATE TABLE IF NOT EXISTS candidates_log (
@@ -175,13 +176,13 @@ export default async function handler(req, res) {
         new_data JSONB NULL
       );
     `);
-    console.log('Ensured candidates_log table exists.');
+    info('Ensured candidates_log table exists.');
 
     await client.query('COMMIT'); // Commit transaction
     res.status(200).json({ success: true, message: 'All tables (recruitment, logs, admission, candidates) verified/updated successfully.' });
   } catch (error) {
     await client.query('ROLLBACK'); // Rollback transaction on error
-    console.error('Erro ao criar/atualizar tabelas:', error);
+    logError('Erro ao criar/atualizar tabelas', { error });
     res.status(500).json({ success: false, error: error.message });
   } finally {
     client.release(); // Release client

--- a/apps/rh/src/pages/api/recruitment-log.ts
+++ b/apps/rh/src/pages/api/recruitment-log.ts
@@ -1,4 +1,5 @@
 import pool from '../../lib/dbPool';
+import { error as logError } from '../../../lib/logger';
 
 
 export default async function handler(req, res) {
@@ -18,7 +19,7 @@ export default async function handler(req, res) {
     );
     res.status(200).json(result.rows);
   } catch (error) {
-    console.error('Erro ao buscar histórico:', error);
+    logError('Erro ao buscar histórico', { error });
     res.status(500).json({ message: 'Erro ao buscar histórico', error: error.message });
   }
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,18 +1,60 @@
 import fs from 'fs';
 import path from 'path';
 
-const logFile = path.join(process.cwd(), 'logs', 'analytics.log');
+const analyticsLogFile = path.join(process.cwd(), 'logs', 'analytics.log');
+const appLogFile = path.join(process.cwd(), 'logs', 'app.log');
 
-export function logAnalytics(service: string, payload: unknown): void {
+function maskSensitive(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(maskSensitive);
+  }
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (/password|secret|token|url/i.test(k)) {
+        result[k] = '***';
+      } else {
+        result[k] = maskSensitive(v);
+      }
+    }
+    return result;
+  }
+  return value;
+}
+
+function writeLog(level: string, message: string, meta?: unknown): void {
   try {
-    fs.mkdirSync(path.dirname(logFile), { recursive: true });
-    const entry = JSON.stringify({
+    fs.mkdirSync(path.dirname(appLogFile), { recursive: true });
+    const entry = {
       timestamp: new Date().toISOString(),
-      service,
-      payload
-    });
-    fs.appendFileSync(logFile, entry + '\n');
+      level,
+      message,
+      meta: maskSensitive(meta)
+    };
+    fs.appendFileSync(appLogFile, JSON.stringify(entry) + '\n');
   } catch {
     // Ignore logging errors
   }
+}
+
+export function logAnalytics(service: string, payload: unknown): void {
+  try {
+    fs.mkdirSync(path.dirname(analyticsLogFile), { recursive: true });
+    const entry = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      service,
+      payload: maskSensitive(payload)
+    });
+    fs.appendFileSync(analyticsLogFile, entry + '\n');
+  } catch {
+    // Ignore logging errors
+  }
+}
+
+export function info(message: string, meta?: unknown): void {
+  writeLog('info', message, meta);
+}
+
+export function error(message: string, meta?: unknown): void {
+  writeLog('error', message, meta);
 }


### PR DESCRIPTION
## Summary
- add general log utilities in `lib/logger`
- refactor recruitment endpoints and sync script to use the logger
- add unit test for logger utilities

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68518071fe6c83329e7be7cf055893fa