### PR TITLE
Wrap apps with shared layout

### DIFF
--- a/apps/autos/__tests__/layout.test.tsx
+++ b/apps/autos/__tests__/layout.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@azure/msal-react', () => ({
+  MsalProvider: ({ children }: any) => <div>{children}</div>,
+  useMsal: () => ({ instance: { getActiveAccount: jest.fn(), loginRedirect: jest.fn() } }),
+  useIsAuthenticated: () => false
+}), { virtual: true })
+jest.mock('@azure/msal-browser', () => ({ PublicClientApplication: jest.fn() }), { virtual: true })
+jest.mock('../../../lib/useAnalytics', () => ({ useAnalytics: () => {} }), { virtual: true })
+jest.mock('next/router', () => ({ useRouter: () => ({ asPath: '/', events: { on: jest.fn(), off: jest.fn() } }) }))
+
+import MyApp from '../src/pages/_app'
+import Home from '../src/pages/index'
+
+describe('App layout', () => {
+  it('renders navigation', () => {
+    render(<MyApp Component={Home} pageProps={{}} />)
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+    expect(screen.getByText('RF Web')).toBeInTheDocument()
+  })
+})

--- a/apps/autos/jest.config.js
+++ b/apps/autos/jest.config.js
@@ -5,7 +5,8 @@ const customConfig = {
   setupFilesAfterEnv: ['<rootDir>/../../jest.setup.ts'],
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
-    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1'
+    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1',
+    '^../../../lib/(.*)$': '<rootDir>/../../lib/$1'
   }
 }
 

--- a/apps/autos/src/pages/_app.tsx
+++ b/apps/autos/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import { MsalProvider } from '@azure/msal-react';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
-import { ThemeProvider } from '@RFWebApp/ui';
+import { ThemeProvider, Layout } from '@RFWebApp/ui';
 import { useAnalytics } from '../../../lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
@@ -20,7 +20,9 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider>
       <MsalProvider instance={msalInstance}>
-        <Component {...pageProps} />
+        <Layout navItems={[{ href: '/autos', label: 'Home' }]}>
+          <Component {...pageProps} />
+        </Layout>
       </MsalProvider>
     </ThemeProvider>
   );

--- a/apps/autos/src/pages/index.tsx
+++ b/apps/autos/src/pages/index.tsx
@@ -1,12 +1,10 @@
-import { Button, Layout } from '@RFWebApp/ui';
+import { Button } from '@RFWebApp/ui';
 
 export default function Home() {
   return (
-    <Layout navItems={[{ href: '/', label: 'Home' }]}>
-      <div className="space-y-2">
-        <div>Autos app</div>
-        <Button>Example Button</Button>
-      </div>
-    </Layout>
+    <div className="space-y-2">
+      <div>Autos app</div>
+      <Button>Example Button</Button>
+    </div>
   );
 }

--- a/apps/core/__tests__/layout.test.tsx
+++ b/apps/core/__tests__/layout.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@azure/msal-react', () => ({
+  MsalProvider: ({ children }: any) => <div>{children}</div>,
+  useMsal: () => ({ instance: { getActiveAccount: jest.fn(), loginRedirect: jest.fn() } }),
+  useIsAuthenticated: () => false
+}), { virtual: true })
+jest.mock('@azure/msal-browser', () => ({ PublicClientApplication: jest.fn() }), { virtual: true })
+jest.mock('@lib/useAnalytics', () => ({ useAnalytics: () => {} }), { virtual: true })
+jest.mock('next/router', () => ({ useRouter: () => ({ asPath: '/', events: { on: jest.fn(), off: jest.fn() } }) }))
+
+import MyApp from '../src/pages/_app'
+import Index from '../src/pages/index'
+
+describe('App layout', () => {
+  it('renders navigation', () => {
+    render(<MyApp Component={Index} pageProps={{}} />)
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+    expect(screen.getByText('RF Web')).toBeInTheDocument()
+  })
+})

--- a/apps/core/src/pages/_app.tsx
+++ b/apps/core/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import { MsalProvider } from '@azure/msal-react';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
-import { ThemeProvider } from '@RFWebApp/ui';
+import { ThemeProvider, Layout } from '@RFWebApp/ui';
 import { useAnalytics } from '@lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
@@ -20,7 +20,15 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider>
       <MsalProvider instance={msalInstance}>
-        <Component {...pageProps} />
+        <Layout
+          navItems={[
+            { href: '/core', label: 'Home' },
+            { href: '/core/apps', label: 'Apps' },
+            { href: '/core/settings', label: 'Settings' }
+          ]}
+        >
+          <Component {...pageProps} />
+        </Layout>
       </MsalProvider>
     </ThemeProvider>
   );

--- a/apps/core/src/pages/landing.tsx
+++ b/apps/core/src/pages/landing.tsx
@@ -4,7 +4,6 @@ import { useIsAuthenticated, useMsal } from '@azure/msal-react';
 import {
   Card,
   Button,
-  Layout,
   Modal,
   ModalContent,
   ModalHeader,
@@ -69,8 +68,7 @@ export default function LandingPage() {
   };
 
   return (
-    <Layout navItems={[{ href: '/core', label: 'Home' }]}>
-      <div className="space-y-6">
+    <div className="space-y-6">
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
           {apps.map((app) => (
             <a key={app.href} href={app.href} className="block">
@@ -104,6 +102,5 @@ export default function LandingPage() {
           </ModalContent>
         </Modal>
       </div>
-    </Layout>
-  );
+    );
 }

--- a/apps/dashboards/__tests__/layout.test.tsx
+++ b/apps/dashboards/__tests__/layout.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@azure/msal-react', () => ({
+  MsalProvider: ({ children }: any) => <div>{children}</div>,
+  useMsal: () => ({ instance: { getActiveAccount: jest.fn(), loginRedirect: jest.fn() } }),
+  useIsAuthenticated: () => false
+}), { virtual: true })
+jest.mock('@azure/msal-browser', () => ({ PublicClientApplication: jest.fn() }), { virtual: true })
+jest.mock('../../../lib/useAnalytics', () => ({ useAnalytics: () => {} }), { virtual: true })
+jest.mock('next/router', () => ({ useRouter: () => ({ asPath: '/', events: { on: jest.fn(), off: jest.fn() } }) }))
+
+import MyApp from '../src/pages/_app'
+import Home from '../src/pages/index'
+
+describe('App layout', () => {
+  it('renders navigation', () => {
+    render(<MyApp Component={Home} pageProps={{}} />)
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+    expect(screen.getByText('RF Web')).toBeInTheDocument()
+  })
+})

--- a/apps/dashboards/jest.config.js
+++ b/apps/dashboards/jest.config.js
@@ -5,7 +5,8 @@ const customConfig = {
   setupFilesAfterEnv: ['<rootDir>/../../jest.setup.ts'],
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
-    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1'
+    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1',
+    '^../../../lib/(.*)$': '<rootDir>/../../lib/$1'
   }
 }
 

--- a/apps/dashboards/src/pages/_app.tsx
+++ b/apps/dashboards/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import { MsalProvider } from '@azure/msal-react';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
-import { ThemeProvider } from '@RFWebApp/ui';
+import { ThemeProvider, Layout } from '@RFWebApp/ui';
 import { useAnalytics } from '../../../lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
@@ -20,7 +20,9 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider>
       <MsalProvider instance={msalInstance}>
-        <Component {...pageProps} />
+        <Layout navItems={[{ href: '/dashboards', label: 'Home' }]}>
+          <Component {...pageProps} />
+        </Layout>
       </MsalProvider>
     </ThemeProvider>
   );

--- a/apps/expenses/__tests__/layout.test.tsx
+++ b/apps/expenses/__tests__/layout.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@azure/msal-react', () => ({
+  MsalProvider: ({ children }: any) => <div>{children}</div>,
+  useMsal: () => ({ instance: { getActiveAccount: jest.fn(), loginRedirect: jest.fn() } }),
+  useIsAuthenticated: () => false
+}), { virtual: true })
+jest.mock('@azure/msal-browser', () => ({ PublicClientApplication: jest.fn() }), { virtual: true })
+jest.mock('../../../lib/useAnalytics', () => ({ useAnalytics: () => {} }), { virtual: true })
+jest.mock('next/router', () => ({ useRouter: () => ({ asPath: '/', events: { on: jest.fn(), off: jest.fn() } }) }))
+
+import MyApp from '../src/pages/_app'
+import Home from '../src/pages/index'
+
+describe('App layout', () => {
+  it('renders navigation', () => {
+    render(<MyApp Component={Home} pageProps={{}} />)
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+    expect(screen.getByText('RF Web')).toBeInTheDocument()
+  })
+})

--- a/apps/expenses/jest.config.js
+++ b/apps/expenses/jest.config.js
@@ -5,7 +5,8 @@ const customConfig = {
   setupFilesAfterEnv: ['<rootDir>/../../jest.setup.ts'],
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
-    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1'
+    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1',
+    '^../../../lib/(.*)$': '<rootDir>/../../lib/$1'
   }
 }
 

--- a/apps/expenses/src/pages/_app.tsx
+++ b/apps/expenses/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import { MsalProvider } from '@azure/msal-react';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
-import { ThemeProvider } from '@RFWebApp/ui';
+import { ThemeProvider, Layout } from '@RFWebApp/ui';
 import { useAnalytics } from '../../../lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
@@ -20,7 +20,9 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider>
       <MsalProvider instance={msalInstance}>
-        <Component {...pageProps} />
+        <Layout navItems={[{ href: '/expenses', label: 'Home' }]}>
+          <Component {...pageProps} />
+        </Layout>
       </MsalProvider>
     </ThemeProvider>
   );

--- a/apps/inventory/__tests__/layout.test.tsx
+++ b/apps/inventory/__tests__/layout.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@azure/msal-react', () => ({
+  MsalProvider: ({ children }: any) => <div>{children}</div>,
+  useMsal: () => ({ instance: { getActiveAccount: jest.fn(), loginRedirect: jest.fn() } }),
+  useIsAuthenticated: () => false
+}), { virtual: true })
+jest.mock('@azure/msal-browser', () => ({ PublicClientApplication: jest.fn() }), { virtual: true })
+jest.mock('../../../lib/useAnalytics', () => ({ useAnalytics: () => {} }), { virtual: true })
+jest.mock('next/router', () => ({ useRouter: () => ({ asPath: '/', events: { on: jest.fn(), off: jest.fn() } }) }))
+
+import MyApp from '../src/pages/_app'
+import Home from '../src/pages/index'
+
+describe('App layout', () => {
+  it('renders navigation', () => {
+    render(<MyApp Component={Home} pageProps={{}} />)
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+    expect(screen.getByText('RF Web')).toBeInTheDocument()
+  })
+})

--- a/apps/inventory/jest.config.js
+++ b/apps/inventory/jest.config.js
@@ -5,7 +5,8 @@ const customConfig = {
   setupFilesAfterEnv: ['<rootDir>/../../jest.setup.ts'],
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
-    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1'
+    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1',
+    '^../../../lib/(.*)$': '<rootDir>/../../lib/$1'
   }
 }
 

--- a/apps/inventory/src/pages/_app.tsx
+++ b/apps/inventory/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import { MsalProvider } from '@azure/msal-react';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
-import { ThemeProvider } from '@RFWebApp/ui';
+import { ThemeProvider, Layout } from '@RFWebApp/ui';
 import { useAnalytics } from '../../../lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
@@ -20,7 +20,9 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider>
       <MsalProvider instance={msalInstance}>
-        <Component {...pageProps} />
+        <Layout navItems={[{ href: '/inventory', label: 'Home' }]}>
+          <Component {...pageProps} />
+        </Layout>
       </MsalProvider>
     </ThemeProvider>
   );

--- a/apps/rh/__tests__/layout.test.tsx
+++ b/apps/rh/__tests__/layout.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@azure/msal-react', () => ({
+  MsalProvider: ({ children }: any) => <div>{children}</div>,
+  useMsal: () => ({ instance: { getActiveAccount: jest.fn(), loginRedirect: jest.fn() } }),
+  useIsAuthenticated: () => false
+}), { virtual: true })
+jest.mock('@azure/msal-browser', () => ({ PublicClientApplication: jest.fn() }), { virtual: true })
+
+jest.mock('../../../lib/useAnalytics', () => ({ useAnalytics: () => {} }), { virtual: true })
+jest.mock('next/router', () => ({ useRouter: () => ({ asPath: '/', events: { on: jest.fn(), off: jest.fn() } }) }))
+
+import MyApp from '../src/pages/_app'
+import Perfil from '../src/pages/perfil'
+
+jest.mock('../src/context/FuncionarioContext', () => ({
+  FuncionarioProvider: ({ children }: any) => <div>{children}</div>
+}))
+
+jest.mock('@/contexts/SelectedEmployeeContext', () => ({
+  SelectedEmployeeProvider: ({ children }: any) => <div>{children}</div>
+}))
+
+describe('App layout', () => {
+  it('renders navigation', () => {
+    render(<MyApp Component={Perfil} pageProps={{}} />)
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+    expect(screen.getByText('RF Web')).toBeInTheDocument()
+  })
+})

--- a/apps/rh/jest.config.js
+++ b/apps/rh/jest.config.js
@@ -5,7 +5,9 @@ const customConfig = {
   setupFilesAfterEnv: ['<rootDir>/../../jest.setup.ts'],
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
-    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1'
+    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1',
+    '^../../../lib/(.*)$': '<rootDir>/../../lib/$1',
+    '^@/(.*)$': '<rootDir>/src/$1'
   }
 }
 

--- a/apps/rh/src/pages/_app.tsx
+++ b/apps/rh/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import { MsalProvider } from '@azure/msal-react';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../config/authConfig';
 import '../styles/globals.css';
-import { ThemeProvider } from '@RFWebApp/ui';
+import { ThemeProvider, Layout } from '@RFWebApp/ui';
 import { useAnalytics } from '../../../lib/useAnalytics';
 import { FuncionarioProvider } from '../context/FuncionarioContext';
 import { SelectedEmployeeProvider } from '@/contexts/SelectedEmployeeContext';
@@ -26,7 +26,16 @@ function MyApp({ Component, pageProps }: AppProps) {
       <MsalProvider instance={msalInstance}>
         <SelectedEmployeeProvider>
           <FuncionarioProvider>
-            <Component {...pageProps} />
+            <Layout
+              navItems={[
+                { href: '/rh/landing', label: 'Home' },
+                { href: '/rh/perfil', label: 'Perfil' },
+                { href: '/rh/recruitment', label: 'Recrutamento' },
+                { href: '/rh/settings', label: 'Settings' }
+              ]}
+            >
+              <Component {...pageProps} />
+            </Layout>
             <ToastContainer position="top-right" autoClose={5000} />
           </FuncionarioProvider>
         </SelectedEmployeeProvider>

--- a/apps/timesheet/__tests__/layout.test.tsx
+++ b/apps/timesheet/__tests__/layout.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@azure/msal-react', () => ({
+  MsalProvider: ({ children }: any) => <div>{children}</div>,
+  useMsal: () => ({ instance: { getActiveAccount: jest.fn(), loginRedirect: jest.fn() } }),
+  useIsAuthenticated: () => false
+}), { virtual: true })
+jest.mock('@azure/msal-browser', () => ({ PublicClientApplication: jest.fn() }), { virtual: true })
+jest.mock('../../../lib/useAnalytics', () => ({ useAnalytics: () => {} }), { virtual: true })
+jest.mock('next/router', () => ({ useRouter: () => ({ asPath: '/', events: { on: jest.fn(), off: jest.fn() } }) }))
+
+import MyApp from '../src/pages/_app'
+import Home from '../src/pages/index'
+
+describe('App layout', () => {
+  it('renders navigation', () => {
+    render(<MyApp Component={Home} pageProps={{}} />)
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+    expect(screen.getByText('RF Web')).toBeInTheDocument()
+  })
+})

--- a/apps/timesheet/jest.config.js
+++ b/apps/timesheet/jest.config.js
@@ -5,7 +5,8 @@ const customConfig = {
   setupFilesAfterEnv: ['<rootDir>/../../jest.setup.ts'],
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
-    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1'
+    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1',
+    '^../../../lib/(.*)$': '<rootDir>/../../lib/$1'
   }
 }
 

--- a/apps/timesheet/src/pages/_app.tsx
+++ b/apps/timesheet/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import { MsalProvider } from '@azure/msal-react';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
-import { ThemeProvider } from '@RFWebApp/ui';
+import { ThemeProvider, Layout } from '@RFWebApp/ui';
 import { useAnalytics } from '../../../lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
@@ -20,7 +20,9 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider>
       <MsalProvider instance={msalInstance}>
-        <Component {...pageProps} />
+        <Layout navItems={[{ href: '/timesheet', label: 'Home' }]}>
+          <Component {...pageProps} />
+        </Layout>
       </MsalProvider>
     </ThemeProvider>
   );

--- a/apps/vendors/__tests__/layout.test.tsx
+++ b/apps/vendors/__tests__/layout.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@azure/msal-react', () => ({
+  MsalProvider: ({ children }: any) => <div>{children}</div>,
+  useMsal: () => ({ instance: { getActiveAccount: jest.fn(), loginRedirect: jest.fn() } }),
+  useIsAuthenticated: () => false
+}), { virtual: true })
+jest.mock('@azure/msal-browser', () => ({ PublicClientApplication: jest.fn() }), { virtual: true })
+jest.mock('../../../lib/useAnalytics', () => ({ useAnalytics: () => {} }), { virtual: true })
+jest.mock('next/router', () => ({ useRouter: () => ({ asPath: '/', events: { on: jest.fn(), off: jest.fn() } }) }))
+
+import MyApp from '../src/pages/_app'
+import Home from '../src/pages/index'
+
+describe('App layout', () => {
+  it('renders navigation', () => {
+    render(<MyApp Component={Home} pageProps={{}} />)
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+    expect(screen.getByText('RF Web')).toBeInTheDocument()
+  })
+})

--- a/apps/vendors/jest.config.js
+++ b/apps/vendors/jest.config.js
@@ -5,7 +5,8 @@ const customConfig = {
   setupFilesAfterEnv: ['<rootDir>/../../jest.setup.ts'],
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
-    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1'
+    '^@RFWebApp/ui(.*)$': '<rootDir>/../../packages/ui/src$1',
+    '^../../../lib/(.*)$': '<rootDir>/../../lib/$1'
   }
 }
 

--- a/apps/vendors/src/pages/_app.tsx
+++ b/apps/vendors/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import { MsalProvider } from '@azure/msal-react';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { authConfig } from '../authConfig';
 import '../styles/globals.css';
-import { ThemeProvider } from '@RFWebApp/ui';
+import { ThemeProvider, Layout } from '@RFWebApp/ui';
 import { useAnalytics } from '../../../lib/useAnalytics';
 
 const msalInstance = new PublicClientApplication({
@@ -20,7 +20,9 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider>
       <MsalProvider instance={msalInstance}>
-        <Component {...pageProps} />
+        <Layout navItems={[{ href: '/vendors', label: 'Home' }]}>
+          <Component {...pageProps} />
+        </Layout>
       </MsalProvider>
     </ThemeProvider>
   );


### PR DESCRIPTION
## Summary
- add a default `<Layout>` wrapper in every app
- clean up pages that imported `Layout`
- provide nav items for each app
- configure Jest path mapping
- add layout smoke tests per app

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68518065e25883328b5b112127918d5a