### PR TITLE
Add GSAP animations with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,27 @@ import { AppShortcutCard } from '@RFWebApp/ui';
 <AppShortcutCard title="RH" icon="👥" href="/rh" />
 ```
 
+Componentes com animações GSAP já incluídas:
+```tsx
+import { Tabs, TabsList, TabsTrigger, TabsContent, TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@RFWebApp/ui';
+
+<Tabs defaultValue="one">
+  <TabsList>
+    <TabsTrigger value="one">One</TabsTrigger>
+    <TabsTrigger value="two">Two</TabsTrigger>
+  </TabsList>
+  <TabsContent value="one">First</TabsContent>
+  <TabsContent value="two">Second</TabsContent>
+</Tabs>
+
+<TooltipProvider>
+  <Tooltip>
+    <TooltipTrigger>Dica</TooltipTrigger>
+    <TooltipContent>Texto auxiliar</TooltipContent>
+  </Tooltip>
+</TooltipProvider>
+```
+
 Tailwind com preset da UI:
 
 ```ts

--- a/packages/ui/src/components/__tests__/app-card.test.tsx
+++ b/packages/ui/src/components/__tests__/app-card.test.tsx
@@ -1,0 +1,15 @@
+jest.mock('gsap', () => ({ gsap: { fromTo: jest.fn(), to: jest.fn() } }))
+
+import { render } from '@testing-library/react'
+import { AppCard } from '../app-card'
+import { gsap } from 'gsap'
+
+jest.mock('next/link', () => ({ __esModule: true, default: ({ children, href }: any) => <a href={href}>{children}</a> }))
+
+describe('AppCard', () => {
+  it('animates on mount', () => {
+    const spy = jest.spyOn(gsap, 'fromTo')
+    render(<AppCard title="Test" description="desc" href="/" />)
+    expect(spy).toHaveBeenCalled()
+  })
+})

--- a/packages/ui/src/components/__tests__/modal.test.tsx
+++ b/packages/ui/src/components/__tests__/modal.test.tsx
@@ -1,0 +1,23 @@
+jest.mock('gsap', () => ({ gsap: { fromTo: jest.fn(), to: jest.fn() } }))
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Modal, ModalTrigger, ModalContent } from '../modal'
+import { gsap } from 'gsap'
+
+jest.mock('next/link', () => ({ __esModule: true, default: ({ children, href }: any) => <a href={href}>{children}</a> }))
+
+describe('Modal', () => {
+  it('animates when opened', async () => {
+    const spy = jest.spyOn(gsap, 'fromTo')
+    render(
+      <Modal>
+        <ModalTrigger>Open</ModalTrigger>
+        <ModalContent>Hi</ModalContent>
+      </Modal>
+    )
+    await userEvent.click(screen.getByText('Open'))
+    await screen.findByText('Hi')
+    expect(spy).toHaveBeenCalled()
+  })
+})

--- a/packages/ui/src/components/__tests__/tabs.test.tsx
+++ b/packages/ui/src/components/__tests__/tabs.test.tsx
@@ -1,0 +1,23 @@
+jest.mock('gsap', () => ({ gsap: { fromTo: jest.fn(), to: jest.fn() } }))
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../tabs'
+import { gsap } from 'gsap'
+
+describe('Tabs', () => {
+  it('animates content on mount', () => {
+    const spy = jest.spyOn(gsap, 'fromTo')
+    render(
+      <Tabs defaultValue="one">
+        <TabsList>
+          <TabsTrigger value="one">One</TabsTrigger>
+          <TabsTrigger value="two">Two</TabsTrigger>
+        </TabsList>
+        <TabsContent value="one">First</TabsContent>
+        <TabsContent value="two">Second</TabsContent>
+      </Tabs>
+    )
+    expect(spy).toHaveBeenCalled()
+  })
+})

--- a/packages/ui/src/components/__tests__/tooltip.test.tsx
+++ b/packages/ui/src/components/__tests__/tooltip.test.tsx
@@ -1,6 +1,9 @@
+jest.mock('gsap', () => ({ gsap: { fromTo: jest.fn(), to: jest.fn() } }))
+
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '../tooltip'
+import { gsap } from 'gsap'
 
 describe('Tooltip', () => {
   it('shows content on hover', async () => {
@@ -15,5 +18,18 @@ describe('Tooltip', () => {
     await userEvent.hover(screen.getByText('Hint'))
     const items = await screen.findAllByText('More info')
     expect(items.length).toBeGreaterThan(0)
+  })
+
+  it('animates on open', () => {
+    const spy = jest.spyOn(gsap, 'fromTo')
+    render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger>Tip</TooltipTrigger>
+          <TooltipContent>Content</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+    expect(spy).toHaveBeenCalled()
   })
 })

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -1,5 +1,7 @@
 import * as React from "react"
+import { useEffect, useRef, useImperativeHandle } from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
+import { gsap } from "gsap"
 import { cn } from "../lib/utils"
 
 const Tabs = TabsPrimitive.Root
@@ -37,16 +39,32 @@ TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, ...props }, ref) => {
+  const localRef = useRef<React.ElementRef<typeof TabsPrimitive.Content>>(null)
+  useImperativeHandle(ref, () => localRef.current)
+  useEffect(() => {
+    const el = localRef.current
+    if (el) {
+      gsap.fromTo(el, { opacity: 0, y: 10 }, { opacity: 1, y: 0 })
+    }
+    return () => {
+      if (el) {
+        gsap.to(el, { opacity: 0, y: -10 })
+      }
+    }
+  }, [])
+
+  return (
+    <TabsPrimitive.Content
+      ref={localRef}
+      className={cn(
+        "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        className
+      )}
+      {...props}
+    />
+  )
+})
 TabsContent.displayName = TabsPrimitive.Content.displayName
 
 export { Tabs, TabsList, TabsTrigger, TabsContent } 

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,5 +1,7 @@
 import * as React from "react"
+import { useEffect, useRef, useImperativeHandle } from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import { gsap } from "gsap"
 import { cn } from "../lib/utils"
 
 const TooltipProvider = TooltipPrimitive.Provider
@@ -9,17 +11,33 @@ const TooltipTrigger = TooltipPrimitive.Trigger
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, sideOffset = 4, ...props }, ref) => {
+  const localRef = useRef<React.ElementRef<typeof TooltipPrimitive.Content>>(null)
+  useImperativeHandle(ref, () => localRef.current)
+  useEffect(() => {
+    const el = localRef.current
+    if (el) {
+      gsap.fromTo(el, { opacity: 0, y: 4 }, { opacity: 1, y: 0 })
+    }
+    return () => {
+      if (el) {
+        gsap.to(el, { opacity: 0, y: -4 })
+      }
+    }
+  }, [])
+
+  return (
+    <TooltipPrimitive.Content
+      ref={localRef}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+})
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
 export { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,6 +14,7 @@ export * from './components/separator';
 export * from './components/switch';
 export * from './components/table';
 export * from './components/tabs';
+export * from './components/tooltip';
 export * from './components/textarea';
 export * from './components/app-card';
 export * from './components/app-shortcut-card';


### PR DESCRIPTION
## Summary
- animate Tabs and Tooltip components on mount/unmount using GSAP
- export Tooltip component from `@rfwebapp/ui`
- add unit tests for mount animations of AppCard, Modal, Tabs and Tooltip
- document animated component usage in README

## Testing
- `pnpm exec jest -c packages/ui/jest.config.js`

------
https://chatgpt.com/codex/tasks/task_e_68518062a3348332b9a48081c1ae4d37