### PR TITLE
Add analytics route tests

### DIFF
--- a/apps/autos/src/pages/api/__tests__/analytics.test.ts
+++ b/apps/autos/src/pages/api/__tests__/analytics.test.ts
@@ -1,0 +1,18 @@
+/** @jest-environment node */
+import handler from '../analytics'
+import { logAnalytics } from '../../../../../../lib/logger'
+
+jest.mock('../../../../../../lib/logger', () => ({
+  logAnalytics: jest.fn()
+}))
+
+describe('analytics API', () => {
+  it('logs payload for autos', () => {
+    const req = { method: 'POST', body: { foo: 'bar' } } as any
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any
+
+    handler(req, res)
+
+    expect(logAnalytics).toHaveBeenCalledWith('autos', req.body)
+  })
+})

--- a/apps/core/src/pages/api/__tests__/analytics.test.ts
+++ b/apps/core/src/pages/api/__tests__/analytics.test.ts
@@ -1,0 +1,18 @@
+/** @jest-environment node */
+import handler from '../analytics'
+import { logAnalytics } from '../../../../../../lib/logger'
+
+jest.mock('../../../../../../lib/logger', () => ({
+  logAnalytics: jest.fn()
+}))
+
+describe('analytics API', () => {
+  it('logs payload for core', () => {
+    const req = { method: 'POST', body: { foo: 'bar' } } as any
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any
+
+    handler(req, res)
+
+    expect(logAnalytics).toHaveBeenCalledWith('core', req.body)
+  })
+})

--- a/apps/dashboards/src/pages/api/__tests__/analytics.test.ts
+++ b/apps/dashboards/src/pages/api/__tests__/analytics.test.ts
@@ -1,0 +1,18 @@
+/** @jest-environment node */
+import handler from '../analytics'
+import { logAnalytics } from '../../../../../../lib/logger'
+
+jest.mock('../../../../../../lib/logger', () => ({
+  logAnalytics: jest.fn()
+}))
+
+describe('analytics API', () => {
+  it('logs payload for dashboards', () => {
+    const req = { method: 'POST', body: { foo: 'bar' } } as any
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any
+
+    handler(req, res)
+
+    expect(logAnalytics).toHaveBeenCalledWith('dashboards', req.body)
+  })
+})

--- a/apps/expenses/src/pages/api/__tests__/analytics.test.ts
+++ b/apps/expenses/src/pages/api/__tests__/analytics.test.ts
@@ -1,0 +1,18 @@
+/** @jest-environment node */
+import handler from '../analytics'
+import { logAnalytics } from '../../../../../../lib/logger'
+
+jest.mock('../../../../../../lib/logger', () => ({
+  logAnalytics: jest.fn()
+}))
+
+describe('analytics API', () => {
+  it('logs payload for expenses', () => {
+    const req = { method: 'POST', body: { foo: 'bar' } } as any
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any
+
+    handler(req, res)
+
+    expect(logAnalytics).toHaveBeenCalledWith('expenses', req.body)
+  })
+})

--- a/apps/inventory/src/pages/api/__tests__/analytics.test.ts
+++ b/apps/inventory/src/pages/api/__tests__/analytics.test.ts
@@ -1,0 +1,18 @@
+/** @jest-environment node */
+import handler from '../analytics'
+import { logAnalytics } from '../../../../../../lib/logger'
+
+jest.mock('../../../../../../lib/logger', () => ({
+  logAnalytics: jest.fn()
+}))
+
+describe('analytics API', () => {
+  it('logs payload for inventory', () => {
+    const req = { method: 'POST', body: { foo: 'bar' } } as any
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any
+
+    handler(req, res)
+
+    expect(logAnalytics).toHaveBeenCalledWith('inventory', req.body)
+  })
+})

--- a/apps/rh/src/pages/api/__tests__/analytics.test.ts
+++ b/apps/rh/src/pages/api/__tests__/analytics.test.ts
@@ -1,0 +1,18 @@
+/** @jest-environment node */
+import handler from '../analytics'
+import { logAnalytics } from '../../../../../../lib/logger'
+
+jest.mock('../../../../../../lib/logger', () => ({
+  logAnalytics: jest.fn()
+}))
+
+describe('analytics API', () => {
+  it('logs payload for rh', () => {
+    const req = { method: 'POST', body: { foo: 'bar' } } as any
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any
+
+    handler(req, res)
+
+    expect(logAnalytics).toHaveBeenCalledWith('rh', req.body)
+  })
+})

--- a/apps/timesheet/src/pages/api/__tests__/analytics.test.ts
+++ b/apps/timesheet/src/pages/api/__tests__/analytics.test.ts
@@ -1,0 +1,18 @@
+/** @jest-environment node */
+import handler from '../analytics'
+import { logAnalytics } from '../../../../../../lib/logger'
+
+jest.mock('../../../../../../lib/logger', () => ({
+  logAnalytics: jest.fn()
+}))
+
+describe('analytics API', () => {
+  it('logs payload for timesheet', () => {
+    const req = { method: 'POST', body: { foo: 'bar' } } as any
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any
+
+    handler(req, res)
+
+    expect(logAnalytics).toHaveBeenCalledWith('timesheet', req.body)
+  })
+})

--- a/apps/vendors/src/pages/api/__tests__/analytics.test.ts
+++ b/apps/vendors/src/pages/api/__tests__/analytics.test.ts
@@ -1,0 +1,18 @@
+/** @jest-environment node */
+import handler from '../analytics'
+import { logAnalytics } from '../../../../../../lib/logger'
+
+jest.mock('../../../../../../lib/logger', () => ({
+  logAnalytics: jest.fn()
+}))
+
+describe('analytics API', () => {
+  it('logs payload for vendors', () => {
+    const req = { method: 'POST', body: { foo: 'bar' } } as any
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any
+
+    handler(req, res)
+
+    expect(logAnalytics).toHaveBeenCalledWith('vendors', req.body)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for each analytics API route to check that the correct service name is sent to `logAnalytics`

## Testing
- `pnpm test` *(fails: cannot connect to Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_6851879082e083328bbb0f3f1e4c72c5