### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 GilMarSil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -272,3 +272,7 @@ em cada mudança de rota e captura falhas globais.
 - [ ] [Adicionar fallback de autenticação](https://github.com/GimMarSil/rf-web-platform/issues/5)
 
 Consulte [docs/roadmap.md](docs/roadmap.md) para mais detalhes sobre estas tarefas.
+
+## Licença
+
+Este projeto é distribuído sob a licença MIT. Consulte o arquivo [LICENSE](LICENSE) para detalhes.

--- a/package.json
+++ b/package.json
@@ -38,5 +38,6 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "zustand": "^4.5.2"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- add MIT license file
- document license in README and package.json

## Testing
- `pnpm lint` *(fails: 1590 errors)*
- `pnpm test` *(fails: DATABASE_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_6851878c3a6c8332bab05e30a7c2b65d