### PR TITLE
Add JS wrapper for env loader and update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ pnpm dev -F core
 | pnpm run dev -F @RFWebApp/ui | Dev mode do pacote UI |
 | pnpm add -F autos @RFWebApp/ui | Adiciona o pacote UI ao microserviço |
 | pnpm run tokens -F @RFWebApp/ui | Exporta cores e espaçamentos do Tailwind |
+| node apps/rh/src/pages/api/create-postgres-tables.js | Cria tabelas no Postgres |
+| node apps/rh/src/pages/api/syncEmployees.js | Sincroniza funcionários para Postgres |
+
+Scripts JavaScript como os acima devem ser executados com `node` a partir da raiz do projeto.
 
 🎨 UI Partilhada: @RFWebApp/ui
 Biblioteca central de componentes estilizados com Tailwind CSS, GSAP e design Ramos Ferreira.

--- a/apps/rh/src/pages/api/create-postgres-tables.js
+++ b/apps/rh/src/pages/api/create-postgres-tables.js
@@ -1,5 +1,5 @@
 // Load environment variables from .env.local
-require('../../../../../lib/loadEnv.ts');
+require('../../../../../lib/loadEnv.js');
 const { Client } = require('pg');
 
 // Configuração Postgres (Railway)

--- a/apps/rh/src/pages/api/syncEmployees.js
+++ b/apps/rh/src/pages/api/syncEmployees.js
@@ -8,7 +8,7 @@
  *************************************************************/
 
 // Load environment variables from .env.local
-require('../../../../../lib/loadEnv.ts');
+require('../../../../../lib/loadEnv.js');
 const { info, error } = require('../../../../../lib/logger.ts');
 const sql = require('mssql');
 const { Client } = require('pg');

--- a/lib/loadEnv.js
+++ b/lib/loadEnv.js
@@ -1,0 +1,3 @@
+const dotenv = require('dotenv');
+dotenv.config({ path: '.env.local' });
+module.exports = {};


### PR DESCRIPTION
## Summary
- add `lib/loadEnv.js` so Node scripts can load `.env.local`
- update `syncEmployees.js` and `create-postgres-tables.js` to require the JS loader
- document running Node scripts in the README

## Testing
- `pnpm lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685187852c0c83328016def833abf520