### PR TITLE
Update auth configuration to use authority env var

### DIFF
--- a/apps/autos/src/authConfig.ts
+++ b/apps/autos/src/authConfig.ts
@@ -1,6 +1,6 @@
 export const authConfig = {
   clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID || '',
-  tenantId: process.env.NEXT_PUBLIC_AZURE_TENANT_ID || '',
+  authority: process.env.NEXT_PUBLIC_AZURE_AUTHORITY || '',
   redirectUri:
     process.env.NEXT_PUBLIC_REDIRECT_URI || 'http://localhost:3000/autos'
 };

--- a/apps/autos/src/pages/_app.tsx
+++ b/apps/autos/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 const msalInstance = new PublicClientApplication({
   auth: {
     clientId: authConfig.clientId,
-    authority: `https://login.microsoftonline.com/${authConfig.tenantId}`,
+    authority: authConfig.authority,
     redirectUri: authConfig.redirectUri
   }
 });

--- a/apps/core/src/authConfig.ts
+++ b/apps/core/src/authConfig.ts
@@ -1,6 +1,6 @@
 export const authConfig = {
   clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID || '',
-  tenantId: process.env.NEXT_PUBLIC_AZURE_TENANT_ID || '',
+  authority: process.env.NEXT_PUBLIC_AZURE_AUTHORITY || '',
   redirectUri:
     process.env.NEXT_PUBLIC_REDIRECT_URI || 'http://localhost:3000/core'
 };

--- a/apps/core/src/pages/_app.tsx
+++ b/apps/core/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 const msalInstance = new PublicClientApplication({
   auth: {
     clientId: authConfig.clientId,
-    authority: `https://login.microsoftonline.com/${authConfig.tenantId}`,
+    authority: authConfig.authority,
     redirectUri: authConfig.redirectUri
   }
 });

--- a/apps/dashboards/src/authConfig.ts
+++ b/apps/dashboards/src/authConfig.ts
@@ -1,6 +1,6 @@
 export const authConfig = {
   clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID || '',
-  tenantId: process.env.NEXT_PUBLIC_AZURE_TENANT_ID || '',
+  authority: process.env.NEXT_PUBLIC_AZURE_AUTHORITY || '',
   redirectUri:
     process.env.NEXT_PUBLIC_REDIRECT_URI || 'http://localhost:3000/dashboards'
 };

--- a/apps/dashboards/src/pages/_app.tsx
+++ b/apps/dashboards/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 const msalInstance = new PublicClientApplication({
   auth: {
     clientId: authConfig.clientId,
-    authority: `https://login.microsoftonline.com/${authConfig.tenantId}`,
+    authority: authConfig.authority,
     redirectUri: authConfig.redirectUri
   }
 });

--- a/apps/expenses/src/authConfig.ts
+++ b/apps/expenses/src/authConfig.ts
@@ -1,6 +1,6 @@
 export const authConfig = {
   clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID || '',
-  tenantId: process.env.NEXT_PUBLIC_AZURE_TENANT_ID || '',
+  authority: process.env.NEXT_PUBLIC_AZURE_AUTHORITY || '',
   redirectUri:
     process.env.NEXT_PUBLIC_REDIRECT_URI || 'http://localhost:3000/expenses'
 };

--- a/apps/expenses/src/pages/_app.tsx
+++ b/apps/expenses/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 const msalInstance = new PublicClientApplication({
   auth: {
     clientId: authConfig.clientId,
-    authority: `https://login.microsoftonline.com/${authConfig.tenantId}`,
+    authority: authConfig.authority,
     redirectUri: authConfig.redirectUri
   }
 });

--- a/apps/inventory/src/authConfig.ts
+++ b/apps/inventory/src/authConfig.ts
@@ -1,6 +1,6 @@
 export const authConfig = {
   clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID || '',
-  tenantId: process.env.NEXT_PUBLIC_AZURE_TENANT_ID || '',
+  authority: process.env.NEXT_PUBLIC_AZURE_AUTHORITY || '',
   redirectUri:
     process.env.NEXT_PUBLIC_REDIRECT_URI || 'http://localhost:3000/inventory'
 };

--- a/apps/inventory/src/pages/_app.tsx
+++ b/apps/inventory/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 const msalInstance = new PublicClientApplication({
   auth: {
     clientId: authConfig.clientId,
-    authority: `https://login.microsoftonline.com/${authConfig.tenantId}`,
+    authority: authConfig.authority,
     redirectUri: authConfig.redirectUri
   }
 });

--- a/apps/rh/src/config/authConfig.ts
+++ b/apps/rh/src/config/authConfig.ts
@@ -1,6 +1,6 @@
 export const authConfig = {
   clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID || '',
-  tenantId: process.env.NEXT_PUBLIC_AZURE_TENANT_ID || '',
+  authority: process.env.NEXT_PUBLIC_AZURE_AUTHORITY || '',
   redirectUri:
     process.env.NEXT_PUBLIC_REDIRECT_URI || 'http://localhost:3000/rh'
 };

--- a/apps/rh/src/pages/_app.tsx
+++ b/apps/rh/src/pages/_app.tsx
@@ -14,7 +14,7 @@ import { ToastContainer } from 'react-toastify';
 const msalInstance = new PublicClientApplication({
   auth: {
     clientId: authConfig.clientId,
-    authority: `https://login.microsoftonline.com/${authConfig.tenantId}`,
+    authority: authConfig.authority,
     redirectUri: authConfig.redirectUri
   }
 });

--- a/apps/timesheet/src/authConfig.ts
+++ b/apps/timesheet/src/authConfig.ts
@@ -1,6 +1,6 @@
 export const authConfig = {
   clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID || '',
-  tenantId: process.env.NEXT_PUBLIC_AZURE_TENANT_ID || '',
+  authority: process.env.NEXT_PUBLIC_AZURE_AUTHORITY || '',
   redirectUri:
     process.env.NEXT_PUBLIC_REDIRECT_URI || 'http://localhost:3000/timesheet'
 };

--- a/apps/timesheet/src/pages/_app.tsx
+++ b/apps/timesheet/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 const msalInstance = new PublicClientApplication({
   auth: {
     clientId: authConfig.clientId,
-    authority: `https://login.microsoftonline.com/${authConfig.tenantId}`,
+    authority: authConfig.authority,
     redirectUri: authConfig.redirectUri
   }
 });

--- a/apps/vendors/src/authConfig.ts
+++ b/apps/vendors/src/authConfig.ts
@@ -1,6 +1,6 @@
 export const authConfig = {
   clientId: process.env.NEXT_PUBLIC_AZURE_CLIENT_ID || '',
-  tenantId: process.env.NEXT_PUBLIC_AZURE_TENANT_ID || '',
+  authority: process.env.NEXT_PUBLIC_AZURE_AUTHORITY || '',
   redirectUri:
     process.env.NEXT_PUBLIC_REDIRECT_URI || 'http://localhost:3000/vendors'
 };

--- a/apps/vendors/src/pages/_app.tsx
+++ b/apps/vendors/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import { useAnalytics } from '@rfwebapp/lib/useAnalytics';
 const msalInstance = new PublicClientApplication({
   auth: {
     clientId: authConfig.clientId,
-    authority: `https://login.microsoftonline.com/${authConfig.tenantId}`,
+    authority: authConfig.authority,
     redirectUri: authConfig.redirectUri
   }
 });


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_AZURE_AUTHORITY` in auth config files
- reference `authConfig.authority` in `_app.tsx`

## Testing
- `pnpm lint` *(fails: React prop-types errors and other lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_6851a7dc4adc8332a2cf6196073b1612