### PR TITLE
Clarify env setup per app

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ cp .env.example .env.local
 ```
 
 Preencha o `.env.local` resultante com as suas credenciais.
-Em seguida, **cada aplicação Next.js precisa carregar as variáveis do seu próprio `.env.local`**. Copie (ou crie um symlink para) este ficheiro em cada pasta `apps/<nome>` para evitar erros de variáveis em falta.
+Em seguida, **cada aplicação Next.js precisa carregar as variáveis do seu próprio `.env.local`**.
+Copie ou crie um symlink deste ficheiro dentro de cada diretório `apps/<nome>`.
+Antes de correr `pnpm dev -F <app>`, confirme que a pasta da app contém o ficheiro para que as variáveis sejam carregadas corretamente.
 
 Cada micro-serviço possui o seu próprio script `dev`. Não existe `pnpm run dev` na raiz.
 Para iniciar uma aplicação específica use `--filter`:
@@ -54,7 +56,7 @@ pnpm dev -F core
 | pnpm run dev -F @RFWebApp/ui | Dev mode do pacote UI |
 | pnpm add -F autos @RFWebApp/ui | Adiciona o pacote UI ao microserviço |
 
-Antes de executar qualquer build, certifique-se de que correu `pnpm install`,
+Antes de executar qualquer build ou o comando `pnpm dev -F <app>`, certifique-se de que correu `pnpm install`,
 copiou `.env.example` para `.env.local` e replicou esse ficheiro (ou um symlink)
 em cada diretório `apps/<nome>`.
 


### PR DESCRIPTION
## Summary
- document copying `.env.local` into each app before running `pnpm dev`

## Testing
- `pnpm exec prettier -w README.md`
- `pnpm lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6851a90e90448332811e4470deba0450