### PR TITLE
Add icons to AppCard and expand apps list

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ SELECT Number, Name FROM Employee WHERE UserId = @upn AND Active = 1
   title="RH"
   description="Gestão de recursos humanos"
   href="/rh"
+  icon={Users}
   locked={!employeeNumber}
 />
 ```

--- a/apps/core/src/pages/apps.tsx
+++ b/apps/core/src/pages/apps.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
 import { AppCard } from '@RFWebApp/ui';
+import {
+  Car,
+  Boxes,
+  Clock,
+  Wallet,
+  Store,
+  LayoutDashboard,
+  Users
+} from 'lucide-react';
 import { useRequireAuth } from '@rfwebapp/lib/useRequireAuth';
 
 export default function AppsPage() {
@@ -9,21 +18,61 @@ export default function AppsPage() {
       title: 'Autos',
       description: 'Autos de medição',
       href: '/autos',
+      icon: Car,
       locked: false
+    },
+    {
+      title: 'Inventory',
+      description: 'Gestão de inventário',
+      href: '/inventory',
+      icon: Boxes,
+      locked: !employee
+    },
+    {
+      title: 'Timesheet',
+      description: 'Registo de horas',
+      href: '/timesheet',
+      icon: Clock,
+      locked: !employee
+    },
+    {
+      title: 'Expenses',
+      description: 'Gestão de despesas',
+      href: '/expenses',
+      icon: Wallet,
+      locked: !employee
+    },
+    {
+      title: 'Vendors',
+      description: 'Comunicação com fornecedores',
+      href: '/vendors',
+      icon: Store,
+      locked: !employee
+    },
+    {
+      title: 'Dashboards',
+      description: 'Relatórios e métricas',
+      href: '/dashboards',
+      icon: LayoutDashboard,
+      locked: !employee
     },
     {
       title: 'RH',
       description: 'Gestão de recursos humanos',
       href: '/rh',
+      icon: Users,
       locked: !employee
     }
   ];
 
   return (
-    <main className="grid grid-cols-1 sm:grid-cols-2 gap-4 p-4" role="main">
-      {apps.map((app) => (
-        <AppCard key={app.href} {...app} />
-      ))}
+    <main className="p-4 space-y-4" role="main">
+      <h2 className="text-xl font-semibold">Escolha uma aplicação</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {apps.map((app) => (
+          <AppCard key={app.href} {...app} />
+        ))}
+      </div>
     </main>
   );
 }

--- a/packages/ui/src/components/app-card.tsx
+++ b/packages/ui/src/components/app-card.tsx
@@ -1,6 +1,6 @@
 import { gsap } from "gsap";
 import Link from "next/link";
-import { Lock } from "lucide-react";
+import { Lock, type LucideIcon } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { Card } from "./card";
 import { cn } from "../lib/utils";
@@ -10,10 +10,11 @@ export interface AppCardProps {
   description: string;
   href: string;
   locked?: boolean;
+  icon?: LucideIcon;
   className?: string;
 }
 
-export function AppCard({ title, description, href, locked, className }: AppCardProps) {
+export function AppCard({ title, description, href, locked, icon: Icon, className }: AppCardProps) {
   const ref = useRef<HTMLAnchorElement | null>(null);
 
   useEffect(() => {
@@ -24,6 +25,7 @@ export function AppCard({ title, description, href, locked, className }: AppCard
 
   const content = (
     <Card className={cn("p-4 relative h-full", className)}>
+      {Icon && <Icon className="w-8 h-8 mb-2 text-muted-foreground" />}
       <h3 className="text-lg font-semibold">{title}</h3>
       <p className="text-sm text-muted-foreground">{description}</p>
       {locked && (


### PR DESCRIPTION
## Summary
- allow passing an icon to `AppCard`
- show icons and all microapps in the Core apps page
- tweak grid layout and add a small heading
- document icon usage in README

## Testing
- `pnpm lint` *(fails: 5356 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851a910fb3c8332939f4bd7bab4534d