### PR TITLE
Update MSAL mocks in core tests

### DIFF
--- a/apps/core/src/__tests__/home.test.tsx
+++ b/apps/core/src/__tests__/home.test.tsx
@@ -1,10 +1,27 @@
 import { render, screen } from '@testing-library/react'
 import Home from '../pages/index'
 
-jest.mock('@azure/msal-react', () => ({
-  useMsal: () => ({ instance: { loginRedirect: jest.fn(), getActiveAccount: () => undefined } }),
-  useIsAuthenticated: () => false
-}))
+jest.mock(
+  '@azure/msal-react',
+  () => ({
+    MsalProvider: ({ children }: any) => <div>{children}</div>,
+    useMsal: () => ({ instance: { loginRedirect: jest.fn(), getActiveAccount: () => undefined } }),
+    useIsAuthenticated: () => false
+  }),
+  { virtual: true }
+)
+
+jest.mock(
+  '@azure/msal-browser',
+  () => ({
+    PublicClientApplication: jest.fn().mockImplementation(() => ({
+      initialize: jest.fn().mockResolvedValue(undefined),
+      loginRedirect: jest.fn(),
+      getActiveAccount: jest.fn()
+    }))
+  }),
+  { virtual: true }
+)
 
 jest.mock('next/router', () => ({
   useRouter: () => ({ replace: jest.fn() })


### PR DESCRIPTION
## Summary
- mock `@azure/msal-browser` in `apps/core` home tests
- align MSAL mocks with other layout tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685273e4ed688332a3bb96d40b65e448