### PR TITLE
Fix README merge markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,11 +256,7 @@ apps/<nome>/
 - `pnpm lint` verifica o código com ESLint.
 - `pnpm test` executa a suite de testes. Consulte [docs/testing-guide.md](docs/testing-guide.md) para mais detalhes.
 - Para erros comuns de configuração veja [docs/troubleshooting.md](docs/troubleshooting.md).
-<<<<<<< codex/corrigir-erro-aadsts900144-na-sessão
-- Lembre-se de correr `pnpm dev -F <app>` a partir da **raiz** sempre que alterar `.env.local`,
-  caso contrário o Next.js não carrega as variáveis.
-=======
->>>>>>> CodexDev
+- Sempre que alterar `.env.local`, execute `pnpm dev -F <app>` a partir da **raiz** para que o Next.js carregue as novas variáveis.
 
 ⚙️ CI/CD
 


### PR DESCRIPTION
## Summary
- clean up leftover merge markers in README
- clarify `pnpm dev` instructions

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685273e283a883328e0ebcf8dbb04afe