### PR TITLE
Add layout component with responsive sidebar

### DIFF
--- a/apps/autos/src/pages/index.tsx
+++ b/apps/autos/src/pages/index.tsx
@@ -1,10 +1,22 @@
-import { Button } from '@RFWebApp/ui';
+import { Button, Layout } from '@RFWebApp/ui';
+
+const sidebar = (
+  <nav className="p-4 space-y-2">
+    <a href="#" className="block">
+      Inicio
+    </a>
+  </nav>
+);
+
+const header = <div className="font-semibold">Autos</div>;
 
 export default function Home() {
   return (
-    <div className="p-4 space-y-2">
-      <div>Autos app</div>
-      <Button>Example Button</Button>
-    </div>
+    <Layout sidebar={sidebar} header={header}>
+      <div className="space-y-2">
+        <div>Autos app</div>
+        <Button>Example Button</Button>
+      </div>
+    </Layout>
   );
 }

--- a/apps/core/src/pages/apps.tsx
+++ b/apps/core/src/pages/apps.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AppCard } from '@RFWebApp/ui';
+import { AppCard, Layout } from '@RFWebApp/ui';
 import {
   Car,
   Boxes,
@@ -10,6 +10,16 @@ import {
   Users
 } from 'lucide-react';
 import { useRequireAuth } from '@rfwebapp/lib/useRequireAuth';
+
+const sidebar = (
+  <nav className="p-4 space-y-2">
+    <a href="/" className="block">
+      Home
+    </a>
+  </nav>
+);
+
+const header = <div className="font-semibold">Apps</div>;
 
 export default function AppsPage() {
   const employee = useRequireAuth();
@@ -66,13 +76,15 @@ export default function AppsPage() {
   ];
 
   return (
-    <main className="p-4 space-y-4" role="main">
-      <h2 className="text-xl font-semibold">Escolha uma aplicação</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-        {apps.map((app) => (
-          <AppCard key={app.href} {...app} />
-        ))}
+    <Layout sidebar={sidebar} header={header}>
+      <div className="space-y-4" role="main">
+        <h2 className="text-xl font-semibold">Escolha uma aplicação</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {apps.map((app) => (
+            <AppCard key={app.href} {...app} />
+          ))}
+        </div>
       </div>
-    </main>
+    </Layout>
   );
 }

--- a/apps/dashboards/src/pages/index.tsx
+++ b/apps/dashboards/src/pages/index.tsx
@@ -1,10 +1,22 @@
-import { Button } from '@RFWebApp/ui';
+import { Button, Layout } from '@RFWebApp/ui';
+
+const sidebar = (
+  <nav className="p-4 space-y-2">
+    <a href="#" className="block">
+      Inicio
+    </a>
+  </nav>
+);
+
+const header = <div className="font-semibold">Dashboards</div>;
 
 export default function Home() {
   return (
-    <div className="p-4 space-y-2">
-      <div>$app app</div>
-      <Button>Example Button</Button>
-    </div>
+    <Layout sidebar={sidebar} header={header}>
+      <div className="space-y-2">
+        <div>$app app</div>
+        <Button>Example Button</Button>
+      </div>
+    </Layout>
   );
 }

--- a/apps/expenses/src/pages/index.tsx
+++ b/apps/expenses/src/pages/index.tsx
@@ -1,10 +1,22 @@
-import { Button } from '@RFWebApp/ui';
+import { Button, Layout } from '@RFWebApp/ui';
+
+const sidebar = (
+  <nav className="p-4 space-y-2">
+    <a href="#" className="block">
+      Inicio
+    </a>
+  </nav>
+);
+
+const header = <div className="font-semibold">Expenses</div>;
 
 export default function Home() {
   return (
-    <div className="p-4 space-y-2">
-      <div>$app app</div>
-      <Button>Example Button</Button>
-    </div>
+    <Layout sidebar={sidebar} header={header}>
+      <div className="space-y-2">
+        <div>$app app</div>
+        <Button>Example Button</Button>
+      </div>
+    </Layout>
   );
 }

--- a/apps/inventory/src/pages/index.tsx
+++ b/apps/inventory/src/pages/index.tsx
@@ -1,10 +1,22 @@
-import { Button } from '@RFWebApp/ui';
+import { Button, Layout } from '@RFWebApp/ui';
+
+const sidebar = (
+  <nav className="p-4 space-y-2">
+    <a href="#" className="block">
+      Inicio
+    </a>
+  </nav>
+);
+
+const header = <div className="font-semibold">Inventory</div>;
 
 export default function Home() {
   return (
-    <div className="p-4 space-y-2">
-      <div>Inventory app</div>
-      <Button>Example Button</Button>
-    </div>
+    <Layout sidebar={sidebar} header={header}>
+      <div className="space-y-2">
+        <div>Inventory app</div>
+        <Button>Example Button</Button>
+      </div>
+    </Layout>
   );
 }

--- a/apps/timesheet/src/pages/index.tsx
+++ b/apps/timesheet/src/pages/index.tsx
@@ -1,10 +1,22 @@
-import { Button } from '@RFWebApp/ui';
+import { Button, Layout } from '@RFWebApp/ui';
+
+const sidebar = (
+  <nav className="p-4 space-y-2">
+    <a href="#" className="block">
+      Inicio
+    </a>
+  </nav>
+);
+
+const header = <div className="font-semibold">Timesheet</div>;
 
 export default function Home() {
   return (
-    <div className="p-4 space-y-2">
-      <div>$app app</div>
-      <Button>Example Button</Button>
-    </div>
+    <Layout sidebar={sidebar} header={header}>
+      <div className="space-y-2">
+        <div>$app app</div>
+        <Button>Example Button</Button>
+      </div>
+    </Layout>
   );
 }

--- a/apps/vendors/src/pages/index.tsx
+++ b/apps/vendors/src/pages/index.tsx
@@ -1,10 +1,22 @@
-import { Button } from '@RFWebApp/ui';
+import { Button, Layout } from '@RFWebApp/ui';
+
+const sidebar = (
+  <nav className="p-4 space-y-2">
+    <a href="#" className="block">
+      Inicio
+    </a>
+  </nav>
+);
+
+const header = <div className="font-semibold">Vendors</div>;
 
 export default function Home() {
   return (
-    <div className="p-4 space-y-2">
-      <div>$app app</div>
-      <Button>Example Button</Button>
-    </div>
+    <Layout sidebar={sidebar} header={header}>
+      <div className="space-y-2">
+        <div>$app app</div>
+        <Button>Example Button</Button>
+      </div>
+    </Layout>
   );
 }

--- a/packages/ui/src/components/layout.tsx
+++ b/packages/ui/src/components/layout.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { cn } from '../lib/utils';
+
+export interface LayoutProps {
+  sidebar: React.ReactNode;
+  header?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function Layout({ sidebar, header, children }: LayoutProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="min-h-screen flex">
+      <div
+        className={cn(
+          'fixed inset-0 z-40 bg-black/60 md:hidden',
+          open ? 'block' : 'hidden'
+        )}
+        onClick={() => setOpen(false)}
+      />
+      <aside
+        className={cn(
+          'fixed z-50 inset-y-0 left-0 w-64 bg-surface border-r transform md:static md:translate-x-0 transition-transform',
+          open ? 'translate-x-0' : '-translate-x-full'
+        )}
+      >
+        {sidebar}
+      </aside>
+      <div className="flex-1 flex flex-col md:ml-64">
+        <header className="h-14 flex items-center justify-between bg-white border-b px-4 md:ml-0">
+          <button className="md:hidden mr-2 p-2" onClick={() => setOpen(true)}>
+            <span className="sr-only">Open sidebar</span>☰
+          </button>
+          {header}
+        </header>
+        <main className="flex-1 p-4">{children}</main>
+      </div>
+    </div>
+  );
+}
+
+export default Layout;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,3 +19,4 @@ export * from './components/app-card';
 export * from './components/modal';
 export * from './components/theme-provider';
 export * from './components/theme-toggle';
+export * from './components/layout';


### PR DESCRIPTION
## Summary
- add responsive `Layout` component with sidebar and header
- export `Layout`
- update example apps to use `Layout`

## Testing
- `pnpm lint` *(fails: setShowSearchResults assigned but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68529d9f5d5883328f601a6fc8985bbe