### PR TITLE
Configure GitHub package publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
+          registry-url: 'https://npm.pkg.github.com'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Authenticate with GitHub Packages
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm --filter ${{ matrix.app }} build

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,9 +3,13 @@
   "version": "0.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "publish": "pnpm publish --access public"
   },
   "dependencies": {
     "gsap": "^3.13.0",


### PR DESCRIPTION
## Summary
- add `pnpm publish` script and publishConfig registry in `packages/ui`
- configure CI to authenticate with GitHub registry

## Testing
- `pnpm install`
- `pnpm lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68529da6f67483329149fe889cb7b854