### PR TITLE
Add pending evaluations list

### DIFF
--- a/apps/rh/src/pages/api/evaluation/pending-reviews.ts
+++ b/apps/rh/src/pages/api/evaluation/pending-reviews.ts
@@ -1,0 +1,44 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { pool } from '../../../lib/db/pool';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res
+      .status(405)
+      .json({ message: `Method ${req.method} Not Allowed` });
+  }
+
+  const managerId = req.query.managerId as string;
+  if (!managerId) {
+    return res
+      .status(400)
+      .json({ message: 'managerId query parameter required' });
+  }
+
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT ee.id AS evaluation_id,
+              ee.employee_id,
+              e.name AS employee_name,
+              em.title AS matrix_title
+       FROM employee_evaluations ee
+       JOIN employees e ON ee.employee_id = e.id
+       JOIN evaluation_matrices em ON ee.matrix_id = em.id
+       WHERE ee.evaluator_id = $1 AND ee.status = 'draft'
+       ORDER BY ee.created_at DESC`,
+      [managerId]
+    );
+
+    res.status(200).json(result.rows);
+  } catch (error) {
+    console.error('Error fetching pending evaluations:', error);
+    res.status(500).json({ message: 'Error fetching pending evaluations' });
+  } finally {
+    client.release();
+  }
+}

--- a/apps/rh/src/pages/evaluation/index.tsx
+++ b/apps/rh/src/pages/evaluation/index.tsx
@@ -1,27 +1,61 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import {
   ClipboardListIcon, // For Matrizes
-  UserGroupIcon,     // For Avaliar Subordinados
-  CollectionIcon,    // For Minhas Avaliações (or similar)
-  ClockIcon,         // For Pendentes
-  CheckCircleIcon,   // For Concluídas
-  DocumentTextIcon,  // For Balanços Pendentes
-  PlusCircleIcon,    // For Nova Matriz
+  UserGroupIcon, // For Avaliar Subordinados
+  CollectionIcon, // For Minhas Avaliações (or similar)
+  ClockIcon, // For Pendentes
+  CheckCircleIcon, // For Concluídas
+  DocumentTextIcon, // For Balanços Pendentes
+  PlusCircleIcon, // For Nova Matriz
   AdjustmentsHorizontalIcon, // for Matrizes de Avaliação button
-  IdentificationIcon, // for Minhas Avaliações button
+  IdentificationIcon // for Minhas Avaliações button
 } from '@heroicons/react/24/outline';
+import { useSelectedEmployee } from '@/contexts/SelectedEmployeeContext';
+
+interface PendingReview {
+  evaluation_id: number;
+  employee_id: string;
+  employee_name: string;
+  matrix_title: string;
+}
 
 // Placeholder data for summary cards - replace with actual data fetching later
 const summaryData = {
   pendingReviews: 1,
   completedReviews: 2,
-  pendingBalances: 2,
+  pendingBalances: 2
 };
 
 const EvaluationDashboardPage = () => {
-  const [activeTab, setActiveTab] = useState<'gestor' | 'colaborador'>('gestor');
+  const [activeTab, setActiveTab] = useState<'gestor' | 'colaborador'>(
+    'gestor'
+  );
+  const { selectedEmployeeId } = useSelectedEmployee();
+  const [pendingReviewsData, setPendingReviewsData] = useState<PendingReview[]>(
+    []
+  );
+
+  useEffect(() => {
+    const fetchPending = async () => {
+      if (!selectedEmployeeId) return;
+      try {
+        const res = await fetch(
+          `/api/evaluation/pending-reviews?managerId=${selectedEmployeeId}`
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setPendingReviewsData(data);
+        } else {
+          console.error('Failed to fetch pending evaluations');
+        }
+      } catch (err) {
+        console.error('Error fetching pending evaluations', err);
+      }
+    };
+    fetchPending();
+  }, [selectedEmployeeId]);
 
   // TODO: Fetch actual data based on user role (manager/employee) and their ID
   // For now, using placeholder data and simple role switching.
@@ -35,7 +69,9 @@ const EvaluationDashboardPage = () => {
       <div className="container mx-auto p-4 md:p-8 bg-gray-50 min-h-screen">
         {/* Header Section */}
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-800 mb-4 sm:mb-0">Avaliação de Desempenho</h1>
+          <h1 className="text-3xl font-bold text-gray-800 mb-4 sm:mb-0">
+            Avaliação de Desempenho
+          </h1>
           <div className="flex space-x-3">
             <Link href="/evaluation/matrices" legacyBehavior>
               <a className="bg-white text-gray-700 hover:bg-gray-100 border border-gray-300 px-4 py-2 rounded-md shadow-sm text-sm font-medium flex items-center">
@@ -43,8 +79,10 @@ const EvaluationDashboardPage = () => {
                 Matrizes de Avaliação
               </a>
             </Link>
-            <button 
-              onClick={() => alert('Navegar para Minhas Avaliações (placeholder)')}
+            <button
+              onClick={() =>
+                alert('Navegar para Minhas Avaliações (placeholder)')
+              }
               className="bg-black text-white hover:bg-gray-800 px-4 py-2 rounded-md shadow-sm text-sm font-medium flex items-center"
             >
               <IdentificationIcon className="h-5 w-5 mr-2" />
@@ -57,25 +95,43 @@ const EvaluationDashboardPage = () => {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
           <div className="bg-white p-6 rounded-lg shadow-md flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-gray-500">Avaliações Pendentes</p>
-              <p className="text-3xl font-semibold text-gray-800">{summaryData.pendingReviews}</p>
-              <p className="text-xs text-gray-400">Avaliações a aguardar preenchimento</p>
+              <p className="text-sm font-medium text-gray-500">
+                Avaliações Pendentes
+              </p>
+              <p className="text-3xl font-semibold text-gray-800">
+                {summaryData.pendingReviews}
+              </p>
+              <p className="text-xs text-gray-400">
+                Avaliações a aguardar preenchimento
+              </p>
             </div>
             <ClockIcon className="h-8 w-8 text-yellow-500" />
           </div>
           <div className="bg-white p-6 rounded-lg shadow-md flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-gray-500">Avaliações Concluídas</p>
-              <p className="text-3xl font-semibold text-gray-800">{summaryData.completedReviews}</p>
-              <p className="text-xs text-gray-400">Avaliações finalizadas este mês</p>
+              <p className="text-sm font-medium text-gray-500">
+                Avaliações Concluídas
+              </p>
+              <p className="text-3xl font-semibold text-gray-800">
+                {summaryData.completedReviews}
+              </p>
+              <p className="text-xs text-gray-400">
+                Avaliações finalizadas este mês
+              </p>
             </div>
             <CheckCircleIcon className="h-8 w-8 text-green-500" />
           </div>
           <div className="bg-white p-6 rounded-lg shadow-md flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-gray-500">Balanços Pendentes</p>
-              <p className="text-3xl font-semibold text-gray-800">{summaryData.pendingBalances}</p>
-              <p className="text-xs text-gray-400">F-RH-04 a aguardar preenchimento</p>
+              <p className="text-sm font-medium text-gray-500">
+                Balanços Pendentes
+              </p>
+              <p className="text-3xl font-semibold text-gray-800">
+                {summaryData.pendingBalances}
+              </p>
+              <p className="text-xs text-gray-400">
+                F-RH-04 a aguardar preenchimento
+              </p>
             </div>
             <DocumentTextIcon className="h-8 w-8 text-blue-500" />
           </div>
@@ -117,8 +173,12 @@ const EvaluationDashboardPage = () => {
         <div className="bg-white p-6 rounded-lg shadow-md">
           {activeTab === 'gestor' && (
             <div>
-              <h2 className="text-xl font-semibold text-gray-700 mb-1">Ações do Gestor</h2>
-              <p className="text-sm text-gray-500 mb-6">Gerencie as avaliações dos seus subordinados.</p>
+              <h2 className="text-xl font-semibold text-gray-700 mb-1">
+                Ações do Gestor
+              </h2>
+              <p className="text-sm text-gray-500 mb-6">
+                Gerencie as avaliações dos seus subordinados.
+              </p>
               <div className="flex flex-col sm:flex-row space-y-3 sm:space-y-0 sm:space-x-4">
                 <Link href="/evaluation/evaluate" legacyBehavior>
                   <a className="w-full sm:w-auto flex-1 bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50">
@@ -131,23 +191,58 @@ const EvaluationDashboardPage = () => {
                   </a>
                 </Link>
               </div>
-              {/* TODO: Add table/list of pending evaluations for manager view here */}
+              {pendingReviewsData.length > 0 ? (
+                <div className="mt-6">
+                  <h3 className="text-lg font-medium text-gray-700 mb-2">
+                    Avaliações Pendentes
+                  </h3>
+                  <table className="min-w-full divide-y divide-gray-200 text-sm">
+                    <thead>
+                      <tr>
+                        <th className="px-3 py-2 text-left font-semibold text-gray-600">
+                          Colaborador
+                        </th>
+                        <th className="px-3 py-2 text-left font-semibold text-gray-600">
+                          Matriz
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200">
+                      {pendingReviewsData.map((pr) => (
+                        <tr key={pr.evaluation_id}>
+                          <td className="px-3 py-2">{pr.employee_name}</td>
+                          <td className="px-3 py-2">{pr.matrix_title}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <p className="mt-6 text-sm text-gray-500">
+                  Nenhuma avaliação pendente.
+                </p>
+              )}
             </div>
           )}
 
           {activeTab === 'colaborador' && (
             <div>
-              <h2 className="text-xl font-semibold text-gray-700 mb-1">Ações do Colaborador</h2>
-              <p className="text-sm text-gray-500 mb-6">Acompanhe o seu desempenho e preencha os seus formulários.</p>
+              <h2 className="text-xl font-semibold text-gray-700 mb-1">
+                Ações do Colaborador
+              </h2>
+              <p className="text-sm text-gray-500 mb-6">
+                Acompanhe o seu desempenho e preencha os seus formulários.
+              </p>
               {/* TODO: Add content for Colaborador view */}
-              <p className="text-center text-gray-500 py-8">Conteúdo do colaborador em desenvolvimento.</p>
+              <p className="text-center text-gray-500 py-8">
+                Conteúdo do colaborador em desenvolvimento.
+              </p>
             </div>
           )}
         </div>
-
       </div>
     </>
   );
 };
 
-export default EvaluationDashboardPage; 
+export default EvaluationDashboardPage;


### PR DESCRIPTION
## Summary
- provide API to list pending reviews for a manager
- show pending evaluations on evaluation dashboard

## Testing
- `npx prettier -w apps/rh/src/pages/api/evaluation/pending-reviews.ts apps/rh/src/pages/evaluation/index.tsx`
- `pnpm lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68529db32ab8833282bd87e8bdc77955