### PR TITLE
Implement active employee helper

### DIFF
--- a/apps/rh/src/lib/activeEmployee.ts
+++ b/apps/rh/src/lib/activeEmployee.ts
@@ -1,0 +1,23 @@
+import { NextApiRequest } from 'next';
+
+/**
+ * Retrieves the active employee number from request headers or cookies.
+ * Header `x-selected-employee-id` takes precedence over the cookie value.
+ * Returns `null` when no identifier is found.
+ */
+export function getActiveEmployeeNumber(req: NextApiRequest): string | null {
+  const headerValue = req.headers['x-selected-employee-id'];
+  const fromHeader = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
+  if (typeof fromHeader === 'string' && fromHeader.trim()) {
+    return fromHeader;
+  }
+
+  const cookieValue = (req as any).cookies?.employeeNumber;
+  if (typeof cookieValue === 'string' && cookieValue.trim()) {
+    return cookieValue;
+  }
+
+  console.warn('Active employee number not found in headers or cookies');
+  return null;
+}

--- a/apps/rh/src/pages/api/evaluation/criteria/[criterionId].ts
+++ b/apps/rh/src/pages/api/evaluation/criteria/[criterionId].ts
@@ -2,6 +2,7 @@ import { NextApiResponse } from 'next';
 import { Pool } from 'pg';
 import { withAuth, AuthenticatedRequest, isAdmin, isManager } from '../../../../middleware/auth';
 import { validateMatrixInput } from '../../../../lib/evaluation/validation';
+import { getActiveEmployeeNumber } from '../../../../lib/activeEmployee';
 
 // TODO: Ideally, use a shared DB pool module
 const pool = new Pool({
@@ -19,16 +20,12 @@ async function getAuthenticatedSystemUserId(req: AuthenticatedRequest): Promise<
 
 // Helper to get the selected Employee ID (e.g., from a custom header or session)
 async function getSelectedEmployeeId(req: AuthenticatedRequest): Promise<string | null> {
-  // TODO: Implement logic to retrieve selected employee ID.
-  // This ID represents the employee profile the user is currently acting as.
-  // It's used for role-based access and business logic (e.g., manager_id, employee_id).
-  const selectedEmployeeId = req.headers['x-selected-employee-id'] as string;
+  const selectedEmployeeId = getActiveEmployeeNumber(req);
   if (!selectedEmployeeId) {
-    console.warn('X-Selected-Employee-ID header not found. Operations may fail authorization.');
+    console.warn('X-Selected-Employee-ID header or employeeNumber cookie not found.');
     return null;
   }
-  console.log(`Retrieved selectedEmployeeId: ${selectedEmployeeId} from header for criterion operations.`);
-  return selectedEmployeeId; 
+  return selectedEmployeeId;
 }
 
 async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise<void> {

--- a/apps/rh/src/pages/api/evaluation/self-evaluations.ts
+++ b/apps/rh/src/pages/api/evaluation/self-evaluations.ts
@@ -3,6 +3,7 @@ import { Pool } from 'pg';
 import { withAuth, AuthenticatedRequest, getUserManager } from '../../../middleware/auth';
 import { withErrorHandler, ValidationError, NotFoundError, AuthorizationError } from '../../../lib/errors';
 import { executeQuery, executeTransaction } from '../../../lib/db/pool';
+import { getActiveEmployeeNumber } from '../../../lib/activeEmployee';
 import { z } from 'zod';
 
 // TODO: Ideally, use a shared DB pool module
@@ -20,14 +21,12 @@ async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string
 
 // Helper to get the selected Employee ID (e.g., from a custom header or session)
 async function getSelectedEmployeeId(req: NextApiRequest): Promise<string | null> {
-  // TODO: Implement logic to retrieve selected employee ID.
-  const selectedEmployeeId = req.headers['x-selected-employee-id'] as string;
+  const selectedEmployeeId = getActiveEmployeeNumber(req);
   if (!selectedEmployeeId) {
     // For self-evaluations, selectedEmployeeId is almost always required.
-    console.warn('X-Selected-Employee-ID header not found for self-evaluations API. This is critical.');
+    console.warn('X-Selected-Employee-ID header or employeeNumber cookie not found for self-evaluations API.');
     return null;
   }
-  console.log(`Retrieved selectedEmployeeId: ${selectedEmployeeId} from header for self-evaluations API.`);
   return selectedEmployeeId;
 }
 


### PR DESCRIPTION
## Summary
- add helper to get employee ID from headers or cookies
- use the helper in self evaluation and criteria endpoints

## Testing
- `pnpm lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `pnpm -r tsc`

------
https://chatgpt.com/codex/tasks/task_e_68529dbae6508332a71062318d9768e1