### PR TITLE
Refactor PG pool usage

### DIFF
--- a/apps/rh/src/lib/evaluation/auth.ts
+++ b/apps/rh/src/lib/evaluation/auth.ts
@@ -1,9 +1,4 @@
-import { Pool } from 'pg';
-
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
+import { pool } from '../db/pool';
 
 export type UserRole = 'employee' | 'manager' | 'hr' | 'admin';
 

--- a/apps/rh/src/lib/evaluation/notificationService.ts
+++ b/apps/rh/src/lib/evaluation/notificationService.ts
@@ -1,9 +1,4 @@
-import { Pool } from 'pg';
-
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
+import { pool } from '../db/pool';
 
 interface NotificationConfig {
   evaluationDueDays: number;

--- a/apps/rh/src/pages/api/candidates.ts
+++ b/apps/rh/src/pages/api/candidates.ts
@@ -1,14 +1,6 @@
-import { Pool } from 'pg';
+import { pool } from '../../lib/db/pool';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
-pool.on('error', (err) => {
-  console.error('Unexpected error on idle client', err);
-  process.exit(-1);
-});
 
 // Define your RH group ID (ensure this is consistent across your app)
 const RH_GROUP_ID = 'a837ee80-f103-4d51-9869-e3b4da6bdeda';

--- a/apps/rh/src/pages/api/candidates/[id].ts
+++ b/apps/rh/src/pages/api/candidates/[id].ts
@@ -1,14 +1,6 @@
-import { Pool } from 'pg';
+import { pool } from '../../../lib/db/pool';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
-pool.on('error', (err) => {
-  console.error('Unexpected error on idle client', err);
-  process.exit(-1);
-});
 
 const RH_GROUP_ID = 'a837ee80-f103-4d51-9869-e3b4da6bdeda';
 

--- a/apps/rh/src/pages/api/evaluation-create-schema.ts
+++ b/apps/rh/src/pages/api/evaluation-create-schema.ts
@@ -1,11 +1,7 @@
-import { Pool } from 'pg';
+import { pool } from '../lib/db/pool';
 import fs from 'fs';
 import path from 'path';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/apps/rh/src/pages/api/evaluation-create-table.ts
+++ b/apps/rh/src/pages/api/evaluation-create-table.ts
@@ -1,13 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../lib/db/pool';
 import fs from 'fs';
 import path from 'path';
 import sql from 'mssql';
 
-const pgPool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 const sqlConfig = {
   user: process.env.SQL_USER,
@@ -26,7 +22,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  const client = await pgPool.connect();
+  const client = await pool.connect();
   try {
     await client.query('BEGIN');
 

--- a/apps/rh/src/pages/api/evaluation-matrices/[matrixId].ts
+++ b/apps/rh/src/pages/api/evaluation-matrices/[matrixId].ts
@@ -1,13 +1,9 @@
 import { NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../../../lib/db/pool';
 import { withAuth, AuthenticatedRequest, isAdmin, getUserDirectReports } from '../../../middleware/auth';
 import { validateMatrixInput } from '../../../lib/evaluation/validation';
 import { validate as validateUUID } from 'uuid';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 // Helper function to check if the user can manage the matrix
 async function canUserManageMatrix(

--- a/apps/rh/src/pages/api/evaluation-matrices/[matrixId]/applicability.ts
+++ b/apps/rh/src/pages/api/evaluation-matrices/[matrixId]/applicability.ts
@@ -1,10 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../../../../lib/db/pool';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
   // TODO: Replace with actual MSAL or equivalent authentication logic

--- a/apps/rh/src/pages/api/evaluation-matrices/[matrixId]/criteria.ts
+++ b/apps/rh/src/pages/api/evaluation-matrices/[matrixId]/criteria.ts
@@ -1,10 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../../../../lib/db/pool';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {
   // TODO: Replace with actual MSAL or equivalent authentication logic

--- a/apps/rh/src/pages/api/evaluation-matrices/index.ts
+++ b/apps/rh/src/pages/api/evaluation-matrices/index.ts
@@ -1,13 +1,9 @@
-import { Pool } from 'pg';
+import { pool } from '../../../../lib/db/pool';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getAllActiveEmployees, getEmployeeDetailsByUserId, getEmployeeDetailsByNumber } from '../../../lib/employeeDbService';
 import { withAuth, AuthenticatedRequest, isAdmin, isManager, getUserDirectReports } from '../../../middleware/auth';
 import { validateMatrixInput } from '../../../lib/evaluation/validation';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 // Helper to set user ID for logging (if available)
 async function setUserForSession(client, userId) {

--- a/apps/rh/src/pages/api/evaluation-matrix/applicability/[matrixId].ts
+++ b/apps/rh/src/pages/api/evaluation-matrix/applicability/[matrixId].ts
@@ -1,10 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../../../../lib/db/pool';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {

--- a/apps/rh/src/pages/api/evaluation/create-table.ts
+++ b/apps/rh/src/pages/api/evaluation/create-table.ts
@@ -1,9 +1,5 @@
-import { Pool } from 'pg';
+import { pool } from '../../../../lib/db/pool';
 
-const pgPool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
@@ -13,7 +9,7 @@ export default async function handler(req, res) {
   console.log('Starting table creation...');
   console.log('Database URL:', process.env.DATABASE_URL ? 'Present' : 'Missing');
 
-  const client = await pgPool.connect();
+  const client = await pool.connect();
   try {
     console.log('Connected to database successfully');
     await client.query('BEGIN');

--- a/apps/rh/src/pages/api/evaluation/criteria/[criterionId].ts
+++ b/apps/rh/src/pages/api/evaluation/criteria/[criterionId].ts
@@ -1,13 +1,9 @@
 import { NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../../../../lib/db/pool';
 import { withAuth, AuthenticatedRequest, isAdmin, isManager } from '../../../../middleware/auth';
 import { validateMatrixInput } from '../../../../lib/evaluation/validation';
 
-// TODO: Ideally, use a shared DB pool module
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false }, // Adjust based on your DB hosting requirements
-});
+// Shared Postgres pool
 
 // Helper to get authenticated user ID (replace with your actual auth logic)
 async function getAuthenticatedSystemUserId(req: AuthenticatedRequest): Promise<string | null> {

--- a/apps/rh/src/pages/api/evaluation/matrices/[matrixId].ts
+++ b/apps/rh/src/pages/api/evaluation/matrices/[matrixId].ts
@@ -1,13 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../../../../lib/db/pool';
 import { canAccessMatrix, canManageMatrix } from '../../../../lib/evaluation/auth';
 import { validateMatrixInput } from '../../../../lib/evaluation/validation';
 import { withAuth, AuthenticatedRequest, isAdmin, isManager } from '../../../../middleware/auth';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 // Helper to get authenticated user ID
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {

--- a/apps/rh/src/pages/api/evaluation/matrices/[matrixId]/applicability.ts
+++ b/apps/rh/src/pages/api/evaluation/matrices/[matrixId]/applicability.ts
@@ -1,12 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../../../../../lib/db/pool';
 import { canAccessMatrix, canManageMatrix } from '../../../../../lib/evaluation/auth';
 import { z } from 'zod';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 // Helper to get authenticated user ID
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {

--- a/apps/rh/src/pages/api/evaluation/matrices/[matrixId]/criteria.ts
+++ b/apps/rh/src/pages/api/evaluation/matrices/[matrixId]/criteria.ts
@@ -1,11 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../../../../../lib/db/pool';
 
-// TODO: Ideally, use a shared DB pool module
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false }, // Adjust based on your DB hosting requirements
-});
+// Shared Postgres pool
 
 // Renamed: Helper to get the actual logged-in system user ID (e.g., from MSAL)
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {

--- a/apps/rh/src/pages/api/evaluation/matrices/index.ts
+++ b/apps/rh/src/pages/api/evaluation/matrices/index.ts
@@ -1,12 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../../../../lib/db/pool';
 import { canManageMatrix } from '../../../../lib/evaluation/auth';
 import { validateMatrixInput } from '../../../../lib/evaluation/validation';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 // Helper to get authenticated user ID
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {

--- a/apps/rh/src/pages/api/evaluation/matrix/[id]/copy.ts
+++ b/apps/rh/src/pages/api/evaluation/matrix/[id]/copy.ts
@@ -1,11 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../../../../lib/db/pool';
 import { getSession } from 'next-auth/react';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {

--- a/apps/rh/src/pages/api/evaluation/matrix/apply.ts
+++ b/apps/rh/src/pages/api/evaluation/matrix/apply.ts
@@ -1,11 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
+import { pool } from '../../../../lib/db/pool';
 import { getSession } from 'next-auth/react';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {

--- a/apps/rh/src/pages/api/evaluation/notifications/index.ts
+++ b/apps/rh/src/pages/api/evaluation/notifications/index.ts
@@ -1,12 +1,8 @@
 import { NextApiResponse } from 'next';
 import { withAuth, AuthenticatedRequest } from '../../../middleware/auth';
 import { isAdmin } from '../../../../lib/auth';
-import { Pool } from 'pg';
+import { pool } from '../../../../../lib/db/pool';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 async function handler(req: AuthenticatedRequest, res: NextApiResponse): Promise<void> {
   if (!req.user) {

--- a/apps/rh/src/pages/api/evaluation/self-evaluations.ts
+++ b/apps/rh/src/pages/api/evaluation/self-evaluations.ts
@@ -1,15 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Pool } from 'pg';
 import { withAuth, AuthenticatedRequest, getUserManager } from '../../../middleware/auth';
 import { withErrorHandler, ValidationError, NotFoundError, AuthorizationError } from '../../../lib/errors';
-import { executeQuery, executeTransaction } from '../../../lib/db/pool';
+import { executeQuery, executeTransaction, pool } from '../../../lib/db/pool';
 import { z } from 'zod';
 
-// TODO: Ideally, use a shared DB pool module
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false }, // Adjust based on your DB hosting requirements
-});
+// Shared Postgres pool is imported above
 
 // Helper to get authenticated user ID (replace with your actual auth logic)
 async function getAuthenticatedSystemUserId(req: NextApiRequest): Promise<string | null> {

--- a/apps/rh/src/pages/api/recruitment-create-table.ts
+++ b/apps/rh/src/pages/api/recruitment-create-table.ts
@@ -1,9 +1,6 @@
-import { Pool } from 'pg';
+import { pool } from '../lib/db/pool';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
+
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/apps/rh/src/pages/api/recruitment-log.ts
+++ b/apps/rh/src/pages/api/recruitment-log.ts
@@ -1,9 +1,6 @@
-import { Pool } from 'pg';
+import { pool } from '../lib/db/pool';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
+
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {

--- a/apps/rh/src/pages/api/recruitment.ts
+++ b/apps/rh/src/pages/api/recruitment.ts
@@ -1,15 +1,6 @@
-import { Pool } from 'pg';
+import { pool } from '../lib/db/pool';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
-// Test connection on startup
-pool.on('error', (err) => {
-  console.error('Unexpected error on idle client', err);
-  process.exit(-1);
-});
 
 // Helper function to normalize dates to YYYY-MM-DD format
 function normalizeDate(date: string | Date | undefined): string {

--- a/apps/rh/src/pages/api/recruitment/[id]/[action].ts
+++ b/apps/rh/src/pages/api/recruitment/[id]/[action].ts
@@ -1,11 +1,7 @@
-import { Pool } from 'pg'; // Assuming you have 'pg' installed
+import { pool } from '../../../../lib/db/pool'; // Shared Postgres pool
 // import { getToken } from 'next-auth/jwt'; // Keep if you plan to use it for more direct auth
 
 // PostgreSQL connection configuration using the DATABASE_URL
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false, // Adjust SSL for Railway if needed
-});
 
 // Define your approver group ID
 const APPROVER_GROUP_ID = "a837ee80-f103-4d51-9869-e3b4da6bdeda"; // Example RH Group ID


### PR DESCRIPTION
## Summary
- centralize Postgres access in `apps/rh/src/lib/db/pool.ts`
- reuse that module across API routes

## Testing
- `pnpm install`
- `pnpm lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68529db88444833289a82d124de3878d